### PR TITLE
services, draft: fix minter order to add recid field to db content

### DIFF
--- a/invenio_drafts_resources/drafts/api.py
+++ b/invenio_drafts_resources/drafts/api.py
@@ -36,7 +36,7 @@ class DraftBase(Record):
         return self.model.fork_id if self.model else None
 
     @classmethod
-    def create(cls, data, record=None, **kwargs):
+    def create(cls, data, id_, fork_version_id=None, **kwargs):
         """Create a new draft instance and store it in the database."""
         with db.session.begin_nested():
             draft = cls(data)
@@ -44,8 +44,8 @@ class DraftBase(Record):
             draft.validate(**kwargs)
 
             draft.model = cls.model_cls(
-                id=record.id if record else None,
-                fork_version_id=record.revision_id if record else None,
+                id=id_,
+                fork_version_id=fork_version_id,
                 expiry_date=draft.expiry_date,
                 status=draft.status,
                 json=draft,

--- a/invenio_drafts_resources/version.py
+++ b/invenio_drafts_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_drafts_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ install_requires = [
     "invenio-records-resources>=0.3.2,<0.4.0",
     "invenio-accounts>=1.3.0",
     "invenio-files-rest>=1.2.0",
-    "invenio-records-permissions>=0.8.0",
+    "invenio-records-permissions>=0.9.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Previously the minting was happening after the the DB and therefore the `recid` was only present in the indexed content. Later on, when publishing the record was re-indexed without the `recid` (since at resolve time from db it was not there). This was causing problems in the search.