### PR TITLE
Command patttern for DraftActionResource

### DIFF
--- a/invenio_drafts_resources/errors.py
+++ b/invenio_drafts_resources/errors.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-Drafts-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Errors."""
+
+from flask_resources.errors import HTTPJSONException
+
+
+class ActionNotConfigured(HTTPJSONException):
+    """Action not configured error."""
+
+    code = 404
+    description = "Not found. Action not configured."
+
+    def __init__(self, action=None, **kwargs):
+        """Constructor."""
+        super(ActionNotConfigured, self).__init__(**kwargs)
+        if action:
+            self.description = f"Action {action} not configured."
+
+
+class CommandNotImplemented(HTTPJSONException):
+    """Command not implemented error."""
+
+    code = 500
+    description = "Command not implemented."
+
+    def __init__(self, cmd_name=None, **kwargs):
+        """Constructor."""
+        super(CommandNotImplemented, self).__init__(**kwargs)
+        if cmd_name:
+            self.description = f"Command {cmd_name} not implemented."

--- a/invenio_drafts_resources/resources/draft.py
+++ b/invenio_drafts_resources/resources/draft.py
@@ -93,10 +93,10 @@ class DraftActionResource(SingletonResource):
         action = resource_requestctx.route["action"]
         try:
             cmd_name = self.config.action_commands[action]
-            cmd_func = getattr(self.service, command)
+            cmd_func = getattr(self.service, cmd_name)
         except KeyError:
             raise ActionNotConfigured(action=action)
-        except NameError:
+        except AttributeError:
             raise CommandNotImplemented(cmd_name)
 
         # NOTE: Due to the route we assume the commands only need

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from invenio_search import RecordsSearch
 
 from invenio_drafts_resources.drafts import DraftBase, DraftMetadataBase
 from invenio_drafts_resources.resources import DraftActionResource, \
-    DraftResource, DraftVersionResource
+    DraftActionResourceConfig, DraftResource, DraftVersionResource
 from invenio_drafts_resources.services import RecordDraftService, \
     RecordDraftServiceConfig
 from invenio_drafts_resources.services.pid_manager import PIDManager, \
@@ -156,6 +156,15 @@ def _record_service():
     return RecordService(config=CustomRecordServiceConfig)
 
 
+class CustomDraftActionResourceConfig(DraftActionResourceConfig):
+    """Draft action resource config."""
+
+    action_commands = {
+        "publish": "publish",
+        "command": "not_implemented"
+    }
+
+
 @pytest.fixture(scope="module")
 def app(app):
     """Application factory fixture."""
@@ -167,7 +176,8 @@ def app(app):
             service=_draft_service()
         ).as_blueprint("draft_resource")
         draft_action_bp = DraftActionResource(
-            service=_draft_service()
+            service=_draft_service(),
+            config=CustomDraftActionResourceConfig
         ).as_blueprint("draft_action_resource")
         draft_version_bp = DraftVersionResource(
             service=_draft_service()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,6 @@ from invenio_records.models import RecordMetadataBase
 from invenio_records_permissions.generators import AnyUser
 from invenio_records_permissions.policies.records import RecordPermissionPolicy
 from invenio_records_resources.resources import RecordResource
-from invenio_records_resources.services import RecordService, \
-    RecordServiceConfig
 from invenio_search import RecordsSearch
 
 from invenio_drafts_resources.drafts import DraftBase, DraftMetadataBase
@@ -79,14 +77,6 @@ class TestSearch(RecordsSearch):
         """Test configuration."""
 
         index = "records"
-
-
-class CustomRecordServiceConfig(RecordServiceConfig):
-    """Custom draft service config."""
-
-    record_cls = CustomRecord
-    search_cls = TestSearch
-    permission_policy_cls = AnyUserPermissionPolicy
 
 
 class CustomPIDManagerConfig(PIDManagerConfig):
@@ -149,11 +139,6 @@ def base_app(base_app):
 def _draft_service():
     """Create a draft service."""
     return RecordDraftService(config=CustomRecordDraftServiceConfig)
-
-
-def _record_service():
-    """Create a record service."""
-    return RecordService(config=CustomRecordServiceConfig)
 
 
 class CustomDraftActionResourceConfig(DraftActionResourceConfig):

--- a/tests/test_draft_resource.py
+++ b/tests/test_draft_resource.py
@@ -171,22 +171,24 @@ def test_create_publish_record_new_version(client, input_record,
 
 
 def test_action_not_configured(client, fake_identity):
-
+    """Tests a non configured action call."""
     # NOTE: recid can be dummy since it won't reach pass the resource view
     response = client.post(
         "/records/1234-abcd/draft/actions/non-configured", headers=HEADERS
     )
 
     assert response.status_code == 404
-    assert response.json['message'] == 'Action non-configured not configured.'
+    assert response.json['message'] == \
+        'Action non-configured not configured.'
 
 
 def test_command_not_implemented(client, fake_identity):
-
+    """Tests a configured action without implemented function."""
     # NOTE: recid can be dummy since it won't reach pass the resource view
     response = client.post(
         "/records/1234-abcd/draft/actions/command", headers=HEADERS
     )
 
     assert response.status_code == 500
-    assert response.json['message'] == 'Command not_implemented not implemented.'
+    assert response.json['message'] == \
+        'Command not_implemented not implemented.'

--- a/tests/test_draft_resource.py
+++ b/tests/test_draft_resource.py
@@ -168,3 +168,25 @@ def test_create_publish_record_new_version(client, input_record,
 
     assert response.json['metadata']['recid'] == recid_2 != recid
     assert response.json['revision'] == 0
+
+
+def test_action_not_configured(client, fake_identity):
+
+    # NOTE: recid can be dummy since it won't reach pass the resource view
+    response = client.post(
+        "/records/1234-abcd/draft/actions/non-configured", headers=HEADERS
+    )
+
+    assert response.status_code == 404
+    assert response.json['message'] == 'Action non-configured not configured.'
+
+
+def test_command_not_implemented(client, fake_identity):
+
+    # NOTE: recid can be dummy since it won't reach pass the resource view
+    response = client.post(
+        "/records/1234-abcd/draft/actions/command", headers=HEADERS
+    )
+
+    assert response.status_code == 500
+    assert response.json['message'] == 'Command not_implemented not implemented.'


### PR DESCRIPTION
Requires #25 

**Note**:

It is not a fully-fledged command pattern. Implementing interfaces with "execute", invoker and receiver seemed a bit of an overkill for what we want: *Easy way to make actions configurable*

closes #31 