### PR TITLE
config: set default action_commands

### DIFF
--- a/invenio_drafts_resources/resources/draft_config.py
+++ b/invenio_drafts_resources/resources/draft_config.py
@@ -40,3 +40,6 @@ class DraftActionResourceConfig(ResourceConfig):
     response_handlers = {
         "application/json": RecordResponse(RecordDraftJSONSerializer())
     }
+    action_commands = {
+        "publish": "publish",
+    }


### PR DESCRIPTION
- closes #47 
- not crucial for release (temporary fix in invenio-rdm-records) 