### PR TITLE
global: enable search by record status

### DIFF
--- a/invenio_drafts_resources/resources/records/resource.py
+++ b/invenio_drafts_resources/resources/records/resource.py
@@ -28,3 +28,19 @@ class RecordResource(_RecordResource):
         item = self.service.create(
             g.identity, data, links_config=self.config.draft_links_config)
         return item.to_dict(), 201
+
+    def search(self):
+        """Perform a search over the items."""
+        identity = g.identity
+        status = resource_requestctx.url_args.pop("status", None)
+
+        if not status:  # To account for `?status=`, which ends up in []
+            status = ["published"]
+
+        hits = self.service.search(
+            identity=identity,
+            params=resource_requestctx.url_args,
+            links_config=self.config.links_config,
+            status="published" if "published" in status else "draft",
+        )
+        return hits.to_dict(), 200

--- a/invenio_drafts_resources/version.py
+++ b/invenio_drafts_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_drafts_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,10 +7,9 @@
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-docker-services-cli up postgresql es
 python -m check_manifest --ignore ".travis-*" && \
 python -m sphinx.cmd.build -qnNW docs docs/_build/html && \
-docker-services-cli up es postgresql redis
+docker-services-cli up es postgresql
 python -m pytest
 tests_exit_code=$?
 docker-services-cli down

--- a/tests/mock_module/api.py
+++ b/tests/mock_module/api.py
@@ -20,7 +20,9 @@ class Record(RecordBase):
         '$schema', 'http://localhost/schemas/records/record-v1.0.0.json')
 
     index = IndexField(
-        'records-record-v1.0.0', search_alias='draftsresources-records')
+        'draftsresources-records-record-v1.0.0',
+        search_alias='draftsresources-records'
+    )
 
 
 class Draft(DraftBase):
@@ -34,4 +36,6 @@ class Draft(DraftBase):
         '$schema', 'http://localhost/schemas/records/record-v1.0.0.json')
 
     index = IndexField(
-        'drafts-draft-v1.0.0', search_alias='draftsresources-drafts')
+        'draftsresources-drafts-draft-v1.0.0',
+        search_alias='draftsresources-drafts'
+    )

--- a/tests/records/test_api.py
+++ b/tests/records/test_api.py
@@ -45,7 +45,10 @@ def test_record_indexing(app, db, es, example_record, indexer):
 
     # Retrieve document from ES
     data = current_search_client.get(
-        'drafts-draft-v1.0.0', id=example_record.id, doc_type='_doc')
+        'draftsresources-drafts-draft-v1.0.0',
+        id=example_record.id,
+        doc_type='_doc'
+    )
 
     # Loads the ES data and compare
     record = Draft.loads(data['_source'])


### PR DESCRIPTION
NOTE: In the future `service.py/search` might be able to use a parent sort of `_search` class like in `_create`.