### PR TITLE
service: validate saved data before publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,11 +85,10 @@ ipython_config.py
 .python-version
 
 # pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control...
+#   of applications. This is a library. As such we don't want any of the pipenv files.
+Pipfile
+Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
@@ -127,5 +126,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-Pipfile

--- a/invenio_drafts_resources/services/records/schema.py
+++ b/invenio_drafts_resources/services/records/schema.py
@@ -10,7 +10,7 @@
 
 from invenio_records_resources.services.records.schema import \
     RecordSchema as RecordSchemaBase
-from marshmallow import fields, pre_load
+from marshmallow import fields
 
 
 class RecordSchema(RecordSchemaBase):
@@ -18,23 +18,3 @@ class RecordSchema(RecordSchemaBase):
 
     conceptid = fields.Str(dump_only=True)
     expires_at = fields.Str(dump_only=True)
-
-    @pre_load
-    def clean(self, data, **kwargs):
-        """Removes dump_only fields."""
-        keys = [
-            '$schema',
-            'conceptid',
-            'conceptpid',
-            'created',
-            'created',
-            'expires_at',
-            'fork_version_id',
-            'pid',
-            'updated',
-            'uuid',
-            'version_id',
-        ]
-        for k in keys:
-            data.pop(k, None)
-        return data

--- a/invenio_drafts_resources/version.py
+++ b/invenio_drafts_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_drafts_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup_requires = [
 
 install_requires = [
     "invenio-pidrelations>=0.1.0,<2.0.0",
-    "invenio-records-resources>=0.12.0,<0.13.0",
+    "invenio-records-resources>=0.12.2,<0.13.0",
 ]
 
 packages = find_packages()

--- a/tests/resources/test_record_resource.py
+++ b/tests/resources/test_record_resource.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,18 +9,7 @@
 
 """Invenio Drafts Resources module to create REST APIs"""
 
-import json
-import time
-
-import pytest
 from mock_module.api import Draft, Record
-from sqlalchemy.orm.exc import NoResultFound
-
-from invenio_drafts_resources.resources import DraftActionResource, \
-    DraftActionResourceConfig, DraftResource, DraftResourceConfig, \
-    DraftVersionResource, DraftVersionResourceConfig
-
-HEADERS = {"content-type": "application/json", "accept": "application/json"}
 
 
 def _assert_single_item_response(response):
@@ -37,33 +26,29 @@ def _assert_single_item_response(response):
 #
 
 
-def test_create_draft(client, input_data, es_clear):
+def test_create_draft(client, headers, input_data, es_clear):
     """Test draft creation of a non-existing record."""
-    response = client.post(
-        "/mocks", data=json.dumps(input_data), headers=HEADERS)
+    response = client.post("/mocks", json=input_data, headers=headers)
 
     assert response.status_code == 201
     _assert_single_item_response(response)
 
 
-def test_read_draft(client, input_data, es_clear):
-    response = client.post(
-        "/mocks", data=json.dumps(input_data), headers=HEADERS)
+def test_read_draft(client, headers, input_data, es_clear):
+    response = client.post("/mocks", json=input_data, headers=headers)
 
     assert response.status_code == 201
 
     recid = response.json['id']
-    response = client.get(
-        "/mocks/{}/draft".format(recid), headers=HEADERS)
+    response = client.get(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 200
 
     _assert_single_item_response(response)
 
 
-def test_update_draft(client, input_data, es_clear):
-    response = client.post(
-        "/mocks", data=json.dumps(input_data), headers=HEADERS)
+def test_update_draft(client, headers, input_data, es_clear):
+    response = client.post("/mocks", json=input_data, headers=headers)
 
     assert response.status_code == 201
     assert response.json['metadata']['title'] == \
@@ -77,9 +62,9 @@ def test_update_draft(client, input_data, es_clear):
 
     # Update draft content
     update_response = client.put(
-        "/mocks/{}/draft".format(recid),
-        data=json.dumps(input_data),
-        headers=HEADERS
+        f"/mocks/{recid}/draft",
+        json=input_data,
+        headers=headers
     )
 
     assert update_response.status_code == 200
@@ -87,45 +72,42 @@ def test_update_draft(client, input_data, es_clear):
     assert update_response.json["id"] == recid
 
     # Check the updates where saved
-    update_response = client.get(
-        "/mocks/{}/draft".format(recid), headers=HEADERS)
+    update_response = client.get(f"/mocks/{recid}/draft", headers=headers)
 
     assert update_response.status_code == 200
     assert update_response.json["metadata"]['title'] == edited_title
     assert update_response.json["id"] == recid
 
 
-def test_delete_draft(client, input_data, es_clear):
-    response = client.post(
-        "/mocks", data=json.dumps(input_data), headers=HEADERS)
+def test_delete_draft(client, headers, input_data, es_clear):
+    response = client.post("/mocks", json=input_data, headers=headers)
 
     assert response.status_code == 201
 
     recid = response.json['id']
 
-    update_response = client.delete(
-        "/mocks/{}/draft".format(recid), headers=HEADERS)
+    update_response = client.delete(f"/mocks/{recid}/draft", headers=headers)
 
     assert update_response.status_code == 204
 
     # Check draft deletion
-    update_response = client.get(
-        "/mocks/{}/draft".format(recid), headers=HEADERS)
+    update_response = client.get(f"/mocks/{recid}/draft", headers=headers)
     assert update_response.status_code == 404
 
 
-def _create_and_publish(client, input_data):
+def _create_and_publish(client, headers, input_data):
     """Create a draft and publish it."""
     # Create the draft
-    response = client.post(
-        "/mocks", data=json.dumps(input_data), headers=HEADERS)
+    response = client.post("/mocks", json=input_data, headers=headers)
 
     assert response.status_code == 201
+
     recid = response.json['id']
 
     # Publish it
     response = client.post(
-        "/mocks/{}/draft/actions/publish".format(recid), headers=HEADERS)
+        f"/mocks/{recid}/draft/actions/publish", headers=headers
+    )
 
     assert response.status_code == 202
     _assert_single_item_response(response)
@@ -133,28 +115,27 @@ def _create_and_publish(client, input_data):
     return recid
 
 
-def test_publish_draft(client, input_data, es_clear):
+def test_publish_draft(client, headers, input_data, es_clear):
     """Test draft publication of a non-existing record.
 
     It has to first create said draft.
     """
-    recid = _create_and_publish(client, input_data)
+    recid = _create_and_publish(client, headers, input_data)
 
     # Check draft does not exists anymore
-    response = client.get(
-        "/mocks/{}/draft".format(recid), headers=HEADERS)
+    response = client.get(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 404
 
     # Check record exists
-    response = client.get("/mocks/{}".format(recid), headers=HEADERS)
+    response = client.get(f"/mocks/{recid}", headers=headers)
 
     assert response.status_code == 200
 
     _assert_single_item_response(response)
 
 
-def test_search_records_and_drafts(client, input_data, es_clear):
+def test_search_records_and_drafts(client, headers, input_data, es_clear):
     """Tests the search over the records index.
 
     Note: The three use cases are set in the same test so there is the
@@ -162,49 +143,48 @@ def test_search_records_and_drafts(client, input_data, es_clear):
           correctly more than one record/draft will be returned.
     """
     # Create a draft
-    response = client.post(
-        "/mocks", data=json.dumps(input_data), headers=HEADERS)
+    response = client.post("/mocks", json=input_data, headers=headers)
     assert response.status_code == 201
     recid = response.json['id']
 
     Draft.index.refresh()
 
-    response = client.get("/mocks?status=draft", headers=HEADERS)
+    response = client.get("/mocks?status=draft", headers=headers)
     assert response.status_code == 200
     assert response.json['hits']['total'] == 1
     assert response.json['hits']['hits'][0]['id'] == recid
 
     # Create a record
-    recid = _create_and_publish(client, input_data)
+    recid = _create_and_publish(client, headers, input_data)
     Record.index.refresh()
 
-    response = client.get("/mocks?status=published", headers=HEADERS)
+    response = client.get("/mocks?status=published", headers=headers)
     assert response.status_code == 200
     assert response.json['hits']['total'] == 1
     assert response.json['hits']['hits'][0]['id'] == recid
 
     # Default to record search
-    response = client.get("/mocks", headers=HEADERS)
+    response = client.get("/mocks", headers=headers)
 
     assert response.status_code == 200
     assert response.json['hits']['total'] == 1
     assert response.json['hits']['hits'][0]['id'] == recid
 
 
-def test_action_not_configured(client, es_clear):
+def test_action_not_configured(client, headers, es_clear):
     """Tests a non configured action call."""
     # NOTE: recid can be dummy since it won't reach pass the resource view
     response = client.post(
-        "/mocks/1234-abcd/draft/actions/non-configured", headers=HEADERS
+        "/mocks/1234-abcd/draft/actions/non-configured", headers=headers
     )
     assert response.status_code == 404
 
 
-def test_command_not_implemented(client, es_clear):
+def test_command_not_implemented(client, headers, es_clear):
     """Tests a configured action without implemented function."""
     # NOTE: recid can be dummy since it won't reach pass the resource view
     response = client.post(
-        "/mocks/1234-abcd/draft/actions/command", headers=HEADERS
+        "/mocks/1234-abcd/draft/actions/command", headers=headers
     )
     assert response.status_code == 500
 
@@ -214,17 +194,14 @@ def test_command_not_implemented(client, es_clear):
 # therefore these tests do not assert their output)
 #
 
-def test_create_publish_new_revision(client, input_data, es_clear):
+def test_create_publish_new_revision(client, headers, input_data, es_clear):
     """Test draft creation of an existing record and publish it."""
-    recid = _create_and_publish(client, input_data)
+    recid = _create_and_publish(client, headers, input_data)
 
     # Create new draft of said record
     orig_title = input_data["metadata"]["title"]
     input_data["metadata"]["title"] = "Edited title"
-    response = client.post(
-        "/mocks/{}/draft".format(recid),
-        headers=HEADERS
-    )
+    response = client.post(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 201
     assert response.json['revision_id'] == 4
@@ -232,16 +209,15 @@ def test_create_publish_new_revision(client, input_data, es_clear):
 
     # Update that new draft
     response = client.put(
-        "/mocks/{}/draft".format(recid),
-        data=json.dumps(input_data),
-        headers=HEADERS
+        f"/mocks/{recid}/draft",
+        json=input_data,
+        headers=headers
     )
 
     assert response.status_code == 200
 
     # Check the actual record was not modified
-    response = client.get(
-        "/mocks/{}".format(recid), headers=HEADERS)
+    response = client.get(f"/mocks/{recid}", headers=headers)
 
     assert response.status_code == 200
     _assert_single_item_response(response)
@@ -249,7 +225,8 @@ def test_create_publish_new_revision(client, input_data, es_clear):
 
     # Publish it to check the increment in reversion
     response = client.post(
-        "/mocks/{}/draft/actions/publish".format(recid), headers=HEADERS)
+        f"/mocks/{recid}/draft/actions/publish", headers=headers
+    )
 
     assert response.status_code == 202
     _assert_single_item_response(response)
@@ -260,59 +237,55 @@ def test_create_publish_new_revision(client, input_data, es_clear):
         input_data["metadata"]["title"]
 
     # Check it was actually edited
-    response = client.get(
-        "/mocks/{}".format(recid), headers=HEADERS)
+    response = client.get(f"/mocks/{recid}", headers=headers)
 
     assert response.json['metadata']['title'] == \
         input_data["metadata"]["title"]
 
 
-def test_mutiple_edit(client, input_data, es_clear):
+def test_mutiple_edit(client, headers, input_data, es_clear):
     """Test the revision_id when editing record multiple times.
 
     This tests the `edit` service method.
     """
     # Needs `app` context because of invenio_access/permissions.py#166
-    recid = _create_and_publish(client, input_data)
+    recid = _create_and_publish(client, headers, input_data)
 
     # Create new draft of said record
-    response = client.post(
-        "/mocks/{}/draft".format(recid), headers=HEADERS)
+    response = client.post(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 201
     assert response.json['revision_id'] == 4
 
     # Request a second edit. Get the same draft (revision_id)
-    response = client.post(
-        "/mocks/{}/draft".format(recid), headers=HEADERS)
+    response = client.post(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 201
     assert response.json['revision_id'] == 4
 
     # Publish it to check the increment in version_id
     response = client.post(
-        "/mocks/{}/draft/actions/publish".format(recid), headers=HEADERS)
+        f"/mocks/{recid}/draft/actions/publish", headers=headers
+    )
 
     assert response.status_code == 202
 
     # Edit again
-    response = client.post(
-        "/mocks/{}/draft".format(recid), headers=HEADERS)
+    response = client.post(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 201
     assert response.json['revision_id'] == 7
 
 
-def test_create_publish_new_version(client, input_data):
+def test_create_publish_new_version(client, headers, input_data):
     """Creates a new version of a record.
 
     Publishes the draft to obtain 2 versions of a record.
     """
-    recid = _create_and_publish(client, input_data)
+    recid = _create_and_publish(client, headers, input_data)
 
     # Create new draft of said record
-    response = client.post(
-        "/mocks/{}/versions".format(recid), headers=HEADERS)
+    response = client.post(f"/mocks/{recid}/versions", headers=headers)
 
     assert response.status_code == 201
     _assert_single_item_response(response)
@@ -321,7 +294,8 @@ def test_create_publish_new_version(client, input_data):
 
     # Publish it to check the increment in version
     response = client.post(
-        "/mocks/{}/draft/actions/publish".format(recid_2), headers=HEADERS)
+        f"/mocks/{recid_2}/draft/actions/publish", headers=headers
+    )
 
     assert response.status_code == 202
     _assert_single_item_response(response)


### PR DESCRIPTION
**EDIT Feb 18 2021**

- closes https://github.com/inveniosoftware/react-invenio-deposit/issues/214
- uses `draft_item.data` for validation via `schema.load`
- :warning: requires https://github.com/inveniosoftware/invenio-records-resources/pull/199 so will fail until that one is released
- the dates error is explicitly tested against in upcoming invenio-rdm-records PR

~~Trying to resolve https://github.com/inveniosoftware/react-invenio-deposit/issues/214
This strange behaviour (see comments) is happening (locally) and I can't put my finger on why. I am using the master branches of all dependencies. I even tried with Max's https://github.com/inveniosoftware/invenio-rdm-records/pull/383/files~~