### PR TITLE
services: unpublished drafts removes files

### DIFF
--- a/invenio_drafts_resources/version.py
+++ b/invenio_drafts_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_drafts_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"


### PR DESCRIPTION
* Ensures that record files, object versions and buckets are properly
  removed when an unpublished record is removed.

* Fixes an issue where a draft could not be deleted due to database
  integrity constraints.