### PR TITLE
services: refresh index on delete

### DIFF
--- a/invenio_drafts_resources/services/records/service.py
+++ b/invenio_drafts_resources/services/records/service.py
@@ -302,11 +302,11 @@ class RecordDraftService(RecordService):
 
         draft.delete(force=force)
         db.session.commit()
-        self.indexer.delete(draft)
+        self.indexer.delete(draft, refresh=True)
 
         # Reindex the record to trigger update of computed values in the
         # available dumpers
         if record:
-            self.indexer.index(record)
+            self.indexer.index(record, arguments={"refresh": True})
 
         return True


### PR DESCRIPTION
* Refresh the index when deleting a record to ensure that a user won't
  see the just deleted record in a search results afterwards.