### PR TITLE
run-tests: forward supplied options and arguments to pytest

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,9 +3,20 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2021 TU Wien.
 #
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
+
+# Usage:
+#   ./run-tests.sh [pytest options and args...]
+#
+# Note: the DB and SEARCH services to use are determined by corresponding environment
+#       variables if they are set -- otherwise, the following defaults are used:
+#       DB=postgresql, SEARCH=elasticsearch
+#
+# Example for using mysql instead of postgresql:
+#    DB=mysql ./run-tests.sh
 
 # Quit on errors
 set -o errexit
@@ -23,7 +34,7 @@ trap cleanup EXIT
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --env)"
-python -m pytest
+python -m pytest $@
 tests_exit_code=$?
 python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest
 exit "$tests_exit_code"


### PR DESCRIPTION
closes inveniosoftware/invenio-app-rdm#675
pretty much the same as inveniosoftware/invenio-app-rdm/pull/690