### PR TITLE
records/service: implement new version creation

### DIFF
--- a/invenio_drafts_resources/records/__init__.py
+++ b/invenio_drafts_resources/records/__init__.py
@@ -9,11 +9,13 @@
 """Drafts data access layer API."""
 
 from .api import Draft, Record
-from .models import DraftMetadataBase, ParentRecordMixin
+from .models import DraftMetadataBase, ParentRecordMixin, \
+    ParentRecordStateMixin
 
 __all__ = (
     "Draft",
     "DraftMetadataBase",
     "ParentRecordMixin",
+    "ParentRecordStateMixin",
     "Record",
 )

--- a/invenio_drafts_resources/records/models.py
+++ b/invenio_drafts_resources/records/models.py
@@ -17,24 +17,109 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy_utils.types import UUIDType
 
 
-def ParentRecordMixin(parent_record_cls):
+class ParentRecordMixin:
     """A mixin factory that add the foreign keys to the parent record.
 
-    It is intended to be added to the "child" record class, e.g.:
-    ``class MyRecord(RecordBase, ParentRecordMixin(MyRecordParentClass))``.
+    Usage:
+
+    .. code-block:: python
+
+        class MyRecord(db.Model, RecordMetadataBase, ParentRecordMixin):
+            __parent_record_model__ = ParentRecordMetadata
     """
-    class Mixin:
-        @declared_attr
-        def parent_id(cls):
-            return db.Column(UUIDType, db.ForeignKey(parent_record_cls.id))
 
-        @declared_attr
-        def parent(cls):
-            return db.relationship(parent_record_cls)
+    __parent_record_model__ = None
 
-        # TODO: Add parent_order and/or parent_latest
-        # TODO: Should both records and drafts have an order?
-    return Mixin
+    @declared_attr
+    def parent_id(cls):
+        """Parent identifier."""
+        # We restrict deletion of the parent record in case a record or draft
+        # exists via database-level trigger.
+        return db.Column(UUIDType, db.ForeignKey(
+            cls.__parent_record_model__.id, ondelete="RESTRICT"))
+
+    @declared_attr
+    def parent(cls):
+        """Relationship to parent record."""
+        return db.relationship(cls.__parent_record_model__)
+
+    parent_index = db.Column(db.Integer, nullable=True)
+    """The version index of the record."""
+
+
+class ParentRecordStateMixin:
+    """Database model mixin to keep the state of the latest and next version.
+
+    We keep this data outside the parent record itself, because we want to
+    update it without impacting the parent record's version counter. The
+    version counter in the parent record we use to determine if we have to
+    reindex all record versions.
+
+    Usage:
+
+    .. code-block:: python
+
+        class MyParentState(db.Model, ParentRecordState):
+            __parent_record_model__ = MyParentRecord
+            __draft_model__ = MyDraft
+            __record_model__ = MyRecord
+    """
+
+    __parent_record_model__ = None
+    __record_model__ = None
+    __draft_model__ = None
+
+    @declared_attr
+    def parent_id(cls):
+        """Parent record identifier."""
+        return db.Column(
+            UUIDType,
+            # 1) If the parent record is deleted, we automatically delete
+            # the state as well via database-level on delete trigger.
+            # 2) A parent can only be deleted, if it has no drafts/records via
+            # FKs from drafts/records to the parent.
+            db.ForeignKey(cls.__parent_record_model__.id, ondelete="CASCADE"),
+            primary_key=True,
+        )
+
+    @declared_attr
+    def latest_id(cls):
+        """UUID of the latest published record/draft.
+
+        Note, since a record and draft share the same UUID, the UUID can be
+        used to get both the record or the draft. It's a foreign key to the
+        record to ensure that the record exists (and thus is published).
+
+        If no record has been published, the value is None.
+        """
+        return db.Column(
+            UUIDType,
+            db.ForeignKey(cls.__record_model__.id),
+            nullable=True,
+        )
+
+    latest_index = db.Column(db.Integer, nullable=True)
+    """The index of the latest published record.
+
+    If no record has been published, the value is None.
+    """
+
+    @declared_attr
+    def next_draft_id(cls):
+        """UUID of the draft for the next version (yet to be published).
+
+        Note, since a record and draft share the same UUID, the UUID can be
+        used to get both the record or the draft. It's a foreign key to the
+        draft, because we use it to track if a draft has been created for the
+        next version.
+
+        If no draft for the next version has been created, the value is None.
+        """
+        return db.Column(
+            UUIDType,
+            db.ForeignKey(cls.__draft_model__.id),
+            nullable=True,
+        )
 
 
 class DraftMetadataBase(RecordMetadataBase):

--- a/invenio_drafts_resources/records/systemfields/__init__.py
+++ b/invenio_drafts_resources/records/systemfields/__init__.py
@@ -9,7 +9,9 @@
 """System fields."""
 
 from .parent import ParentField
+from .versions import VersionsField
 
 __all__ = (
     "ParentField",
+    "VersionsField",
 )

--- a/invenio_drafts_resources/records/systemfields/versions.py
+++ b/invenio_drafts_resources/records/systemfields/versions.py
@@ -1,0 +1,259 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Drafts-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Versions field."""
+
+import uuid
+from copy import copy
+
+from invenio_db import db
+from invenio_records.systemfields import RelatedModelField
+from invenio_records.systemfields.base import SystemField
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
+
+
+def uuid_or_none(val):
+    """Convert string to UUID object."""
+    if val is not None and not isinstance(val, uuid.UUID):
+        return uuid.UUID(val)
+    return val
+
+
+class VersionsManager:
+    """Versions state manager."""
+
+    def __init__(self, record, dump=None):
+        """Initialize the versions manager."""
+        self._record = record
+        self._state = None
+        if dump is not None:
+            self.load(dump)
+
+    def copy_to(self, record):
+        """Create a copy of the version manager and set on another record."""
+        record.model.parent_index = self.parent_index
+        version_manager = self.__class__(record)
+        version_manager._state = self._state
+        return version_manager
+
+    #
+    # Record managed attributes
+    #
+    @property
+    def model_cls(self):
+        """Get versions state management model."""
+        return self._record.versions_model_cls
+
+    @property
+    def parent_id(self):
+        """Get versions state management model."""
+        return self._record.model.parent_id
+
+    @property
+    def parent_index(self):
+        """Get the parent index."""
+        return self._record.model.parent_index
+
+    #
+    # Parent managed attributes
+    #
+    @property
+    def latest_id(self):
+        """The id of the latest published record/draft."""
+        return self.state().latest_id
+
+    @property
+    def latest_index(self):
+        """The index of the latest published record/draft."""
+        return self.state().latest_index
+
+    @property
+    def next_draft_id(self):
+        """The id of the next draft (and record)."""
+        return self.state().next_draft_id
+
+    #
+    # Computed attributes
+    #
+    @property
+    def is_latest(self):
+        """Check if the record/draft id is the latest published record id."""
+        return self.latest_id == self._record.id
+
+    @property
+    def is_latest_draft(self):
+        """Check if the record/draft id is the latest draft id."""
+        if self.next_draft_id:
+            return self.next_draft_id == self._record.id
+        else:
+            return self.latest_id == self._record.id
+
+    @property
+    def next_index(self):
+        """Get the next parent index."""
+        return self.latest_index + 1 if self.latest_index is not None else 1
+
+    #
+    # State management methods
+    #
+    def state(self, refresh=False):
+        """Retrieve the versions state."""
+        if self._state is None or refresh:
+            # Get object if it exists
+            self._state = self.model_cls.query.filter_by(
+                parent_id=self.parent_id).one_or_none()
+            if self._state is None:
+                # Object doesn't exists, so create it.
+                self._state = self.model_cls(parent_id=self.parent_id)
+                db.session.add(self._state)
+        return self._state
+
+    def set_next(self):
+        """Set this record as the next draft."""
+        self.state().next_draft_id = self._record.id
+        self._record.model.parent_index = self.next_index
+
+    def clear_next(self):
+        """Unset this record as the next draft."""
+        self.state().next_draft_id = None
+        self._record.model.parent_index = None
+
+    def set_latest(self):
+        """Set this record as the latest published record."""
+        self.state().latest_id = self._record.id
+        self.state().latest_index = self.parent_index
+        self.state().next_draft_id = None
+
+    #
+    # Dump/load
+    #
+    def dump(self):
+        """Dump the versions state to the index."""
+        return dict(
+            latest_id=self.latest_id,
+            latest_index=self.latest_index,
+            next_draft_id=self.next_draft_id,
+            is_latest=self.is_latest,
+            is_latest_draft=self.is_latest_draft,
+            parent_index=self.parent_index,
+        )
+
+    def load(self, dump):
+        """Load the state."""
+        self._state = self.model_cls(
+            parent_id=self.parent_id,
+            latest_id=uuid_or_none(dump['latest_id']),
+            latest_index=dump['latest_index'],
+            next_draft_id=uuid_or_none(dump['next_draft_id']),
+        )
+        if self.parent_index != dump['parent_index']:
+            self._record.model.parent_index = dump['parent_index']
+
+    def __repr__(self):
+        """Return repr(self)."""
+        return (
+            "<{} (parent_id: {}, latest_id: {}, latest_index: {}, "
+            "next_draft_id: {})>"
+        ).format(
+            type(self).__name__,
+            self.parent_id,
+            self.latest_id,
+            self.latest_index,
+            self.next_draft_id,
+        )
+
+
+class VersionsField(SystemField):
+    """Versions field."""
+
+    def __init__(self, create=True, set_next=False, set_latest=False):
+        """Initialise the versions field."""
+        self._create = create
+        self._set_next = set_next
+        self._set_latest = set_latest
+        super().__init__()
+
+    def obj(self, record):
+        """Get the version manager."""
+        obj = self._get_cache(record)
+        if obj is not None:
+            return obj
+        obj = VersionsManager(record)
+        self._set_cache(record, obj)
+        return obj
+
+    def set_obj(self, record, versions):
+        """Set an version manager on the record."""
+        assert isinstance(versions, VersionsManager)
+        versions = versions.copy_to(record)
+        self._set_cache(record, versions)
+
+    #
+    # Record life-cycle hooks
+    #
+    def post_create(self, record):
+        """Called after a record is created."""
+        # The parent record is created on pre_create.
+        versions = self.obj(record)
+        if self._create and self._set_next:
+            # if fork is none - it's a new?
+            versions.set_next()
+        elif self._create and self._set_latest:
+            versions.set_latest()
+
+    def pre_delete(self, record, force=False):
+        """Called before a record is deleted."""
+        if force:
+            versions = self.obj(record)
+            versions.clear_next()
+
+    def pre_dump(self, record, data, dumper=None):
+        """Called before a record is dumped."""
+        parent = getattr(record, self.attr_name)
+        if parent:
+            data[self.attr_name] = self.obj(record).dump()
+
+    def post_load(self, record, data, loader=None):
+        """Called after a record was loaded."""
+        dump = record.pop(self.attr_name, None)
+        if dump:
+            versions = VersionsManager(record, dump=dump)
+            setattr(record, self.attr_name, versions)
+
+    #
+    # Data descriptor API
+    #
+    def __get__(self, record, owner=None):
+        """Get the value for the field.
+
+        Called when the field is accessed, e.g:
+
+        .. code-block:: python
+
+            # Access by object
+            record.versions
+            # Access by object
+            Record.versions
+        """
+        if record is None:
+            # access by class
+            return self
+        # access by object
+        return self.obj(record)
+
+    def __set__(self, record, obj):
+        """Assign a value to the field.
+
+        Called when a value is assigned to the field, e.g.:
+
+        .. code-block:: python
+
+            record.versions = <obj>
+        """
+        self.set_obj(record, obj)

--- a/invenio_drafts_resources/services/records/components.py
+++ b/invenio_drafts_resources/services/records/components.py
@@ -15,7 +15,7 @@ from invenio_records_resources.services.records.components import \
 class PIDComponent(ServiceComponent):
     """Service component for PID registraion."""
 
-    def publish(self, draft=None, record=None):
+    def publish(self, identity, draft=None, record=None):
         """Register persistent identifiers when publishing."""
         if not record.is_published:
             record.register()
@@ -32,8 +32,16 @@ class PIDComponent(ServiceComponent):
 class DraftFilesComponent(ServiceComponent):
     """Draft files service component."""
 
+    def edit(self, identity, draft=None, record=None):
+        """Edit callback."""
+        draft['files'] = record['files']
+
+    def new_version(self, identity, draft=None, record=None):
+        """New version callback."""
+        draft['files'] = record['files']
+
     # TODO: Add tests for publishing a draft with files
-    def publish(self, draft=None, record=None):
+    def publish(self, identity, draft=None, record=None):
         """Copy bucket and files to record."""
         draft_files = draft.files
         bucket = draft_files.bucket
@@ -95,8 +103,14 @@ class DraftMetadataComponent(MetadataComponent):
         """Update draft metadata."""
         record.metadata = data.get('metadata', {})
 
+    def publish(self, identity, draft=None, record=None, **kwargs):
+        """Update draft metadata."""
+        record.metadata = draft.get('metadata', {})
 
-class RelationsComponent(ServiceComponent):
-    """Service component for PID relations integration."""
+    def edit(self, identity, draft=None, record=None, **kwargs):
+        """Update draft metadata."""
+        draft.metadata = record.get('metadata', {})
 
-    # PIDNodeVersioning(pid=conceptrecid).insert_draft_child(child_pid=recid)
+    def new_version(self, identity, draft=None, record=None, **kwargs):
+        """Update draft metadata."""
+        draft.metadata = record.get('metadata', {})

--- a/invenio_drafts_resources/services/records/permissions.py
+++ b/invenio_drafts_resources/services/records/permissions.py
@@ -20,6 +20,8 @@ class RecordDraftPermissionPolicy(RecordPermissionPolicy):
     # Default create should be "authenticated"?
     # TODO: Subclass records-resources policy and add *_draft actions
     can_create = [AnyUser()]
+    can_new_version = [AnyUser()]
+    can_edit = [AnyUser()]
     can_publish = [AnyUser()]
     can_read_draft = [AnyUser()]
     can_update_draft = [AnyUser()]

--- a/invenio_drafts_resources/services/records/schema.py
+++ b/invenio_drafts_resources/services/records/schema.py
@@ -10,11 +10,28 @@
 
 from invenio_records_resources.services.records.schema import \
     RecordSchema as RecordSchemaBase
-from marshmallow import fields
+from marshmallow import Schema, fields
+from marshmallow_utils.fields import NestedAttribute
+
+
+class VersionsSchema(Schema):
+    """Versions schema."""
+
+    is_latest = fields.Boolean()
+    is_latest_draft = fields.Boolean()
+    parent_index = fields.Integer()
+
+
+class ParentSchema(Schema):
+    """Parent record schema."""
+
+    id = fields.Str()
 
 
 class RecordSchema(RecordSchemaBase):
     """Schema for records in JSON."""
 
-    conceptid = fields.Str(dump_only=True)
+    parent = NestedAttribute(ParentSchema, dump_only=True)
+    versions = NestedAttribute(VersionsSchema, dump_only=True)
+    is_published = fields.Boolean(dump_only=True)
     expires_at = fields.Str(dump_only=True)

--- a/invenio_drafts_resources/services/records/service.py
+++ b/invenio_drafts_resources/services/records/service.py
@@ -7,7 +7,7 @@
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
-"""RecordDraft Service API."""
+"""Primary service for working with records and drafts."""
 
 from elasticsearch_dsl.query import Q
 from invenio_db import db
@@ -18,15 +18,10 @@ from .config import RecordDraftServiceConfig
 
 
 class RecordDraftService(RecordService):
-    """Draft Service interface.
+    """Record and draft service interface.
 
-    This service provides an interface to business logic for
-    published AND draft records. When creating a custom service
-    for a specialized record (e.g. authors), consider if you need
-    draft functionality or not. If you do, inherit from this service;
-    otherwise, inherit from the RecordService directly.
-
-    This service includes versioning.
+    This service provides an interface to business logic for published and
+    draft records.
     """
 
     default_config = RecordDraftServiceConfig
@@ -93,6 +88,7 @@ class RecordDraftService(RecordService):
         # Permissions
         self.require_permission(identity, "update_draft", record=draft)
 
+        # Load data with service schema
         data, errors = self.schema.load(
             identity,
             data,
@@ -109,6 +105,7 @@ class RecordDraftService(RecordService):
                 component.update_draft(
                     identity, record=draft, data=data)
 
+        # Commit and index
         draft.commit()
         db.session.commit()
         self.indexer.index(draft)
@@ -137,47 +134,27 @@ class RecordDraftService(RecordService):
     def edit(self, id_, identity, links_config=None):
         """Create a new revision or a draft for an existing record.
 
-        Note: Because of the workflow, this method does not accept data.
         :param id_: record PID value.
         """
-        self.require_permission(identity, "create")
-
         # Draft exists - return it
         try:
             draft = self.draft_cls.pid.resolve(id_, registered_only=False)
+            self.require_permission(identity, "edit", record=draft)
             return self.result_item(
                 self, identity, draft, links_config=links_config)
         except NoResultFound:
             pass
 
-        # Draft does not exists - so get the main record we want edit and
-        # create a draft by 1) either undeleting a soft-deleted draft or 2)
-        # create a new draft
+        # Draft does not exists - so get the main record we want to edit and
+        # create a draft from it
         record = self.record_cls.pid.resolve(id_)
-        try:
-            # We soft-delete a draft once it has been published, in order to
-            # keep the version_id counter around for optimistic concurrency
-            # control (both for ES indexing and for REST API clients)
-            draft = self.draft_cls.get_record(record.id, with_deleted=True)
-            if draft.is_deleted:
-                draft.undelete()
-                draft.update(**record)
-                draft.pid = record.pid
-                draft.fork_version_id = record.revision_id
-        except NoResultFound:
-            # If a draft was ever force deleted, then we will create the draft.
-            # This is a very exceptional case as normally, when we edit a
-            # record then the soft-deleted draft exists and we are in above
-            # case.
-            draft = self.draft_cls.create(
-                record, id_=record.id, fork_version_id=record.revision_id,
-                pid=record.pid,
-            )
+        self.require_permission(identity, "edit", record=record)
+        draft = self.draft_cls.edit(record)
 
         # Run components
         for component in self.components:
-            if hasattr(component, 'edit'):
-                component.edit(identity, draft=draft)
+            if hasattr(component, "edit"):
+                component.edit(identity, draft=draft, record=record)
 
         draft.commit()
         db.session.commit()
@@ -199,90 +176,79 @@ class RecordDraftService(RecordService):
               (drafts can be incomplete but only complete drafts can be turned
               into records)
             - Create or update associated (published) record with data
-
-        NOTE: This process of taking data from the database and validating it
-              back is tricky because there are a number of
-              data representations and transformations. There can be mistakes
-              within it as of writing. Don't take this flow as gospel yet.
         """
         self.require_permission(identity, "publish")
 
-        # Get data layer draft
+        # Get the draft
         draft = self.draft_cls.pid.resolve(id_, registered_only=False)
 
-        # Convert to service layer draft result item
-        draft_item = self.result_item(
-            self, identity, draft, links_config=None  # no need for links
-        )
-        # Convert to data projection i.e. draft result item's dict form. Since
-        # there are no "errors" bc projection is taken directly from
-        # DB, we can use draft_item.data. This dict form is what is
-        # serialized out/deserialized in so it "should" be valid input to load.
-        draft_data = draft_item.data
+        # Validate the draft strictly - since a draft can be saved with errors
+        # we do a strict validation here to make sure only valid drafts can be
+        # published.
+        self._validate_draft(identity, draft)
 
-        # Purely used for validation purposes although we may actually want to
-        # use it...
-        data, _ = self.schema.load(
-            identity,
-            data=draft_data,
-            pid=draft.pid,
-            record=draft,
-            raise_errors=True  # this is the default, but might as well be
-                               # explicit
-        )
-
-        # Set draft data in record
-        if draft.is_published:
-            record = self.record_cls.get_record(draft.id)
-            record.update_from(draft)
-        else:
-            # New record
-            record = self.record_cls.create_from(draft)
+        # Create the record from the draft
+        record = self.record_cls.publish(draft)
+        latest_id = draft.versions.latest_id
 
         # Run components
         for component in self.components:
             if hasattr(component, 'publish'):
-                component.publish(draft=draft, record=record)
+                component.publish(identity, draft=draft, record=record)
 
+        # Commit and index
         record.commit()
-        draft.delete()
-        db.session.commit()  # Persist DB
+        draft.delete(force=False)
+        db.session.commit()
         self.indexer.delete(draft)
         self.indexer.index(record)
+        if latest_id:
+            self._reindex_latest(latest_id)
 
         return self.result_item(
             self, identity, record, links_config=links_config)
 
     def new_version(self, id_, identity, links_config=None):
         """Create a new version of a record."""
-        self.require_permission(identity, "create")
-
-        # Get record
+        # Get the a record - i.e. you can only create a new version in case
+        # at least one published record already exists.
         record = self.record_cls.pid.resolve(id_)
 
-        # Create new draft
-        draft = self.draft_cls.create(
-            {},
-            conceptpid=record.conceptpid,
-            # TODO: Need to check if below line is correct?
-            fork_version_id=record.revision_id,
-        )
+        # Check permissions
+        self.require_permission(identity, "new_version", record=record)
+
+        # Draft for new version already exists? if so return it
+        if record.versions.next_draft_id:
+            next_draft = self.draft_cls.get_record(
+                record.versions.next_draft_id)
+            return self.result_item(
+                self, identity, next_draft, links_config=links_config)
+
+        # Draft for new version does not exists, so create it
+        next_draft = self.draft_cls.new_version(record)
+        # Get the latest published record if it's not the current one.
+        if not record.versions.is_latest:
+            record = self.record_cls.get_record(record.versions.latest_id)
 
         # Run components
         for component in self.components:
             if hasattr(component, 'new_version'):
-                component.new_version(identity, draft=draft, record=record)
+                component.new_version(
+                    identity, draft=next_draft, record=record)
 
-        draft.commit()
+        # Commit and index
+        next_draft.commit()
         db.session.commit()
-        self.indexer.index(draft)
+        self.indexer.index(next_draft)
+        self._reindex_latest(next_draft.versions.latest_id, record=record)
 
         return self.result_item(
-            self, identity, draft, links_config=links_config)
+            self, identity, next_draft, links_config=links_config)
 
     def delete_draft(self, id_, identity, revision_id=None):
         """Delete a record from database and search indexes."""
         draft = self.draft_cls.pid.resolve(id_, registered_only=False)
+        latest_id = draft.versions.latest_id
 
         self.check_revision_id(draft, revision_id)
 
@@ -306,16 +272,78 @@ class RecordDraftService(RecordService):
                 component.delete_draft(
                     identity, draft=draft, record=record, force=force)
 
+        # Note, the parent record deletion logic is implemented in the
+        # ParentField and will automatically take care of deleting the parent
+        # record in case this is the only draft that exists for the parent.
         draft.delete(force=force)
         db.session.commit()
+
         # We refresh the index because users are usually redirected to a
         # search result immediately after, and we don't want the users to see
         # their just deleted draft.
         self.indexer.delete(draft, refresh=True)
 
-        # Reindex the record to trigger update of computed values in the
-        # available dumpers
-        if record:
+        if force:
+            # Case 1: We deleted a new draft (without a published record) or a
+            # new version draft (without a published).
+            # In this case, we reindex the latest published record/draft
+            self._reindex_latest(latest_id, refresh=True)
+        else:
+            # Case 2: We deleted a draft for a published record.
+            # In this case we reindex just the published record to trigger and
+            # update of computed values.
             self.indexer.index(record, arguments={"refresh": True})
 
         return True
+
+    def _validate_draft(self, identity, draft):
+        """Validate a draft.
+
+        This method is internal because it works with a data access layer
+        draft, and thus should not be called from outside the service.
+        """
+        # Convert to draft into service layer draft result item (a record
+        # projection for the given identity). This way we can load and validate
+        # the data with the service schema.
+        draft_item = self.result_item(
+            self, identity, draft, links_config=None  # no need for links
+        )
+        # Validate the data - will raise ValidationError if not valid.
+        self.schema.load(
+            identity,
+            data=draft_item.data,
+            pid=draft.pid,
+            record=draft,
+            raise_errors=True  # this is the default, but might as well be
+                               # explicit
+        )
+
+    def _reindex_latest(self, latest_id, record=None, draft=None,
+                        refresh=False):
+        """Reindex the latest published record and draft.
+
+        This triggers and update of computed values in the index, such as
+        "is_latest".
+
+        This method is internal because it works with a data access layer
+        record/draft, and thus should not be called from outside the service.
+        """
+        arguments = {"refresh": True} if refresh else {}
+
+        # We only have a draft, no latest to index
+        if not latest_id:
+            return
+
+        # Note, the record may not be the latest published record, and we only
+        # want to index the latest published.
+        if record is None or latest_id != record.id:
+            record = self.record_cls.get_record(latest_id)
+        self.indexer.index(record, arguments=arguments)
+
+        # Note, a draft may or may not exists for a published record (depending
+        # on if it's being edited).
+        try:
+            draft = self.draft_cls.get_record(latest_id)
+            self.indexer.index(draft, arguments=arguments)
+        except NoResultFound:
+            pass

--- a/invenio_drafts_resources/version.py
+++ b/invenio_drafts_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_drafts_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/tests/mock_module/api.py
+++ b/tests/mock_module/api.py
@@ -7,9 +7,9 @@ from invenio_drafts_resources.records.api import Draft as DraftBase
 from invenio_drafts_resources.records.api import \
     ParentRecord as ParentRecordBase
 from invenio_drafts_resources.records.api import Record as RecordBase
-from invenio_drafts_resources.records.systemfields import ParentField
 
-from .models import DraftMetadata, ParentRecordMetadata, RecordMetadata
+from .models import DraftMetadata, ParentRecordMetadata, ParentState, \
+    RecordMetadata
 
 
 class ParentRecord(ParentRecordBase):
@@ -28,6 +28,8 @@ class Record(RecordBase):
 
     # Configuration
     model_cls = RecordMetadata
+    versions_model_cls = ParentState
+    parent_record_cls = ParentRecord
 
     # System fields
     schema = ConstantField(
@@ -38,19 +40,14 @@ class Record(RecordBase):
         search_alias='draftsresources-records'
     )
 
-    parent = ParentField(
-        ParentRecord, create=False, soft_delete=False, hard_delete=False)
-
-    create_from_draft = [
-        'parent'
-    ]
-
 
 class Draft(DraftBase):
     """Example record API."""
 
     # Configuration
     model_cls = DraftMetadata
+    versions_model_cls = ParentState
+    parent_record_cls = ParentRecord
 
     # System fields
     schema = ConstantField(
@@ -60,6 +57,3 @@ class Draft(DraftBase):
         'draftsresources-drafts-draft-v1.0.0',
         search_alias='draftsresources-drafts'
     )
-
-    parent = ParentField(
-        ParentRecord, create=True, soft_delete=False, hard_delete=True)

--- a/tests/mock_module/models.py
+++ b/tests/mock_module/models.py
@@ -4,7 +4,7 @@ from invenio_db import db
 from invenio_records.models import RecordMetadataBase
 
 from invenio_drafts_resources.records import DraftMetadataBase, \
-    ParentRecordMixin
+    ParentRecordMixin, ParentRecordStateMixin
 
 
 class ParentRecordMetadata(db.Model, RecordMetadataBase):
@@ -13,15 +13,23 @@ class ParentRecordMetadata(db.Model, RecordMetadataBase):
     __tablename__ = 'parent_mock_metadata'
 
 
-class DraftMetadata(db.Model, DraftMetadataBase,
-                    ParentRecordMixin(ParentRecordMetadata)):
+class DraftMetadata(db.Model, DraftMetadataBase, ParentRecordMixin):
     """Model for mock module metadata."""
 
     __tablename__ = 'draft_mock_metadata'
+    __parent_record_model__ = ParentRecordMetadata
 
 
-class RecordMetadata(db.Model, RecordMetadataBase,
-                     ParentRecordMixin(ParentRecordMetadata)):
+class RecordMetadata(db.Model, RecordMetadataBase, ParentRecordMixin):
     """Model for mock module metadata."""
 
     __tablename__ = 'record_mock_metadata'
+    __parent_record_model__ = ParentRecordMetadata
+
+
+class ParentState(db.Model, ParentRecordStateMixin):
+    """Model for mock module for parent state."""
+
+    __parent_record_model__ = ParentRecordMetadata
+    __record_model__ = RecordMetadata
+    __draft_model__ = DraftMetadata

--- a/tests/mock_module/permissions.py
+++ b/tests/mock_module/permissions.py
@@ -9,6 +9,8 @@ from invenio_drafts_resources.services.records.permissions import \
 class PermissionPolicy(RecordDraftPermissionPolicy):
     """Mock permission policy. All actions allowed."""
 
+    can_edit = [AnyUser()]
+    can_new_version = [AnyUser()]
     can_search = [AnyUser()]
     can_create = [AnyUser()]
     can_read = [AnyUser()]

--- a/tests/records/test_api.py
+++ b/tests/records/test_api.py
@@ -12,6 +12,8 @@ import pytest
 from invenio_search import current_search_client
 from jsonschema import ValidationError
 from mock_module.api import Draft, ParentRecord, Record
+from mock_module.models import DraftMetadata, ParentRecordMetadata, \
+    ParentState, RecordMetadata
 from sqlalchemy import inspect
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -47,12 +49,141 @@ def test_draft_create_parent(app, db):
     assert draft.pid.object_uuid != draft.parent.pid.object_uuid
 
 
+def test_draft_create_parent_state(app, db):
+    """Test draft creation of the parent record."""
+    draft = Draft.create({})
+    db.session.commit()
+
+    # Assert that associated objects were created
+    assert ParentState.query.count() == 1
+    assert DraftMetadata.query.count() == 1
+    assert ParentRecordMetadata.query.count() == 1
+    assert RecordMetadata.query.count() == 0
+
+    def assert_state(d):
+        # An initial draft is not published, so latest_id/index is None
+        assert d.model.parent_index == 1
+        assert d.versions.parent_index == 1
+        assert d.versions.latest_id is None
+        assert d.versions.latest_index is None
+        assert d.versions.next_draft_id == d.id
+
+    assert_state(draft)
+    assert_state(Draft.get_record(draft.id))
+
+
+def test_record_create_parent_state(app, db):
+    """Test draft creation of the parent record."""
+    draft = Draft.create({})
+    draft.commit()
+    db.session.commit()
+    record = Record.publish(draft)
+    record.commit()
+    db.session.commit()
+
+    def assert_state(r):
+        # An initial draft is not published, so latest_id/index is None
+        assert r.versions.latest_id == r.id
+        assert r.versions.latest_index == 1
+        assert r.versions.next_draft_id is None
+        assert r.versions.parent_index == 1
+        assert r.versions.is_latest is True
+        assert r.versions.is_latest_draft is True
+        assert r.model.parent_index == 1
+        assert r.model.parent_id == draft.model.parent_id
+
+    assert_state(record)
+    assert_state(Record.get_record(record.id))
+
+
+def test_draft_create_new_version(app, db):
+    """Test draft creation of the parent record."""
+    # A published record.
+    record = Record.publish(Draft.create({}))
+    db.session.commit()
+    # Create a draft for a new version (happens in service.new_version())
+    draft = Draft.new_version(record)
+    draft.commit()
+    db.session.commit()
+
+    record = Record.get_record(record.id)
+    draft = Draft.get_record(draft.id)
+
+    assert record.id != draft.id  # different uuids
+    assert record.parent.id == draft.parent.id  # same parent
+    assert draft.versions.is_latest_draft is True
+    assert draft.versions.is_latest is False
+    assert record.versions.is_latest_draft is False
+    assert record.versions.is_latest is True
+
+
+def test_draft_parent_state_hard_delete(app, db):
+    """Test force deletion of a draft."""
+    # Initial state: Only draft exists (i.e. no other record versions)
+    draft = Draft.create({})
+    db.session.commit()
+    # happens on:
+    # - service.delete_draft for an *unpublished* record
+    draft.delete(force=True)
+    db.session.commit()
+    # Make sure no parent and no parent state is left-behind
+    assert ParentState.query.count() == 0
+    assert ParentRecordMetadata.query.count() == 0
+    assert DraftMetadata.query.count() == 0
+    assert RecordMetadata.query.count() == 0
+
+
+def test_draft_parent_state_hard_delete_with_parent(app, db):
+    """Test force deletion of a draft."""
+    # Initial state: A previous reccord version exists, in addition to draft
+    draft = Draft.create({})
+    record = Record.create({}, parent=draft.parent)
+    db.session.commit()
+    # happens on:
+    # - service.delete_draft for an *unpublished* record
+    draft.delete(force=True)
+    db.session.commit()
+    # Make sure parent/parent state is still there
+    assert ParentState.query.count() == 1
+    assert ParentRecordMetadata.query.count() == 1
+    assert RecordMetadata.query.count() == 1
+    assert DraftMetadata.query.count() == 0
+
+    record = Record.get_record(record.id)
+    assert record.versions.next_draft_id is None
+    assert record.versions.latest_id == record.id
+
+
+def test_draft_parent_state_soft_delete(app, db):
+    """Test soft deletion of a draft."""
+    # Simulate a record being edited.
+    draft = Draft.create({})
+    record = Record.create({}, parent=draft.parent)
+    db.session.commit()
+    # happens on:
+    # - service.publish()
+    # - service.delete_draft() for a *published* record
+    draft.delete(force=False)
+    db.session.commit()
+
+    assert ParentState.query.count() == 1
+    assert ParentRecordMetadata.query.count() == 1
+    assert RecordMetadata.query.count() == 1
+
+    record = Record.get_record(record.id)
+    assert record.versions.next_draft_id is None
+    assert record.versions.latest_id == record.id
+
+
 #
 # Create/Update from draft
 #
 def test_create_record_from_draft(app, db, example_draft):
-    """Test create a record from a draft."""
-    record = Record.create_from(example_draft)
+    """Test create a record from a draft.
+
+    This is used e.g. when publishing a new draft as a record.
+    """
+    record = Record.publish(example_draft)
     db.session.commit()
     assert example_draft.pid == record.pid
     assert example_draft.parent == record.parent
@@ -115,8 +246,11 @@ def test_draft_dump_load_idempotence(app, db, example_draft):
     assert example_draft == loaded_draft
     # Parent was dumped and loaded
     assert example_draft.parent == loaded_draft.parent
+    assert example_draft.versions.is_latest_draft \
+        == loaded_draft.versions.is_latest_draft
     # Test that SQLAlchemy model was loaded from the JSON and not DB.
     assert not inspect(loaded_draft.parent.model).persistent
+    assert not inspect(loaded_draft.versions._state).persistent
 
 
 #
@@ -143,6 +277,8 @@ def test_draft_indexing(app, db, es, example_draft, indexer):
     assert draft.updated == example_draft.updated
     assert draft.expires_at == example_draft.expires_at
     assert draft.parent == example_draft.parent
+    assert draft.versions.is_latest_draft == \
+        example_draft.versions.is_latest_draft
 
     # Check system fields
     draft.metadata == example_draft['metadata']

--- a/tests/resources/test_record_resource.py
+++ b/tests/resources/test_record_resource.py
@@ -168,7 +168,7 @@ def test_create_publish_new_revision(client, headers, input_data, es_clear):
     response = client.post(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 201
-    assert response.json['revision_id'] == 4
+    assert response.json['revision_id'] == 5
     _assert_single_item_response(response)
 
     # Update that new draft
@@ -219,13 +219,13 @@ def test_mutiple_edit(client, headers, input_data, es_clear):
     response = client.post(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 201
-    assert response.json['revision_id'] == 4
+    assert response.json['revision_id'] == 5
 
     # Request a second edit. Get the same draft (revision_id)
     response = client.post(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 201
-    assert response.json['revision_id'] == 4
+    assert response.json['revision_id'] == 5
 
     # Publish it to check the increment in version_id
     response = client.post(
@@ -238,7 +238,7 @@ def test_mutiple_edit(client, headers, input_data, es_clear):
     response = client.post(f"/mocks/{recid}/draft", headers=headers)
 
     assert response.status_code == 201
-    assert response.json['revision_id'] == 7
+    assert response.json['revision_id'] == 8
 
 
 @pytest.mark.skip()  # Disable until properly implemented.


### PR DESCRIPTION
closes inveniosoftware/invenio-rdm-records#435

This is the Draft-Resources part of versioning. The RDM-Records part is still missing, but this one can be reviewed independently from RDM-Records.