### PR TITLE
service: check permission after getting the latest record

### DIFF
--- a/invenio_drafts_resources/services/records/service.py
+++ b/invenio_drafts_resources/services/records/service.py
@@ -89,11 +89,12 @@ class RecordDraftService(RecordService):
         """Retrieve latest record."""
         # Resolve and require permission
         record = self.record_cls.pid.resolve(id_)
-        self.require_permission(identity, "read", record=record)
 
         # Retrieve latest if record is not
         if not record.versions.is_latest:
             record = self.record_cls.get_record(record.versions.latest_id)
+
+        self.require_permission(identity, "read", record=record)
 
         return self.result_item(
             self, identity, record, links_config=links_config)


### PR DESCRIPTION
Check permission after we have retrieved the latest record as the user might not have access rights to get the latest record but indeed have rights to see the current record.