### PR TITLE
records: reuse parent record for versions

### DIFF
--- a/invenio_drafts_resources/records/api.py
+++ b/invenio_drafts_resources/records/api.py
@@ -94,7 +94,7 @@ class Record(RecordBase):
         """Get all sibling records for the specified parent record."""
         versions = cls.model_cls.query.filter_by(parent_id=parent.id).all()
         return [
-            cls(rec_model.data, model=rec_model)
+            cls(rec_model.data, model=rec_model, parent=parent)
             for rec_model in versions
         ]
 

--- a/invenio_drafts_resources/version.py
+++ b/invenio_drafts_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_drafts_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.14.3"
+__version__ = "0.14.4"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2021 CERN.
 # Copyright (C) 2020 Northwestern University.
 # Copyright (C) 2021 TU Wien.
 #
@@ -24,17 +24,38 @@ set -o errexit
 # Quit on unbound symbols
 set -o nounset
 
-# Always bring down docker services
-function cleanup() {
-    eval "$(docker-services-cli down --env)"
+# Define function for bringing down services
+function cleanup {
+  eval "$(docker-services-cli down --env)"
 }
-trap cleanup EXIT
 
+# Check for arguments
+# Note: "-k" would clash with "pytest"
+keep_services=0
+pytest_args=()
+for arg in $@; do
+	# from the CLI args, filter out some known values and forward the rest to "pytest"
+	# note: we don't use "getopts" here b/c of some limitations (e.g. long options),
+	#       which means that we can't combine short options (e.g. "./run-tests -Kk pattern")
+	case ${arg} in
+		-K|--keep-services)
+			keep_services=1
+			;;
+		*)
+			pytest_args+=( ${arg} )
+			;;
+	esac
+done
+
+if [[ ${keep_services} -eq 0 ]]; then
+	trap cleanup EXIT
+fi
 
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --env)"
-python -m pytest $@
+# Note: expansion of pytest_args looks like below to not cause an unbound
+# variable error when 1) "nounset" and 2) the array is empty.
+python -m pytest ${pytest_args[@]+"${pytest_args[@]}"}
 tests_exit_code=$?
-python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest
 exit "$tests_exit_code"

--- a/tests/records/test_api.py
+++ b/tests/records/test_api.py
@@ -304,6 +304,7 @@ def test_draft_delete_reindex(app, db, es, example_draft, indexer):
     db.session.commit()
     assert indexer.index(draft)['result'] == 'created'
 
+
 #
 # Get by parent
 #

--- a/tests/records/test_api.py
+++ b/tests/records/test_api.py
@@ -303,3 +303,24 @@ def test_draft_delete_reindex(app, db, es, example_draft, indexer):
     draft.commit()
     db.session.commit()
     assert indexer.index(draft)['result'] == 'created'
+
+#
+# Get by parent
+#
+def test_get_records_by_parent(app, db, location):
+    """Test get by parent."""
+    # Create two published records
+    record_v1 = Record.publish(Draft.create({}))
+    db.session.commit()
+    draft = Draft.new_version(record_v1)
+    draft.commit()
+    db.session.commit()
+    record_v2 = Record.publish(draft)
+    db.session.commit()
+
+    # Get all two versions.
+    parent = record_v2.parent
+    records = Record.get_records_by_parent(parent)
+
+    # Check that we reuse the parent we passed in.
+    assert id(parent) == id(records[0].parent) == id(records[1].parent)


### PR DESCRIPTION
* Reuse the parent record when fetching all record versions. Usually we
  get all record versions when we want to reindex all versions (e.g.
  parent was updated). Thus, we inject the parent record into all
  versions, so we avoid having to refetch the parent from the database
  for every record version.