### PR TITLE
release: v0.16.2

### DIFF
--- a/invenio_drafts_resources/version.py
+++ b/invenio_drafts_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_drafts_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.16.1"
+__version__ = "0.16.2"


### PR DESCRIPTION
triggered by [release v0.35.4](https://github.com/inveniosoftware/invenio-rdm-records/commit/ba4707a7c3e10197f5fbb6c4f99b1631ae7f212c) of invenio-rdm-records which contains the service registration rename.