### PR TITLE
Include drafts in reindexing of related records

### DIFF
--- a/invenio_drafts_resources/services/records/service.py
+++ b/invenio_drafts_resources/services/records/service.py
@@ -535,6 +535,11 @@ class RecordService(RecordServiceBase):
         siblings = self.record_cls.get_records_by_parent(
             parent or record.parent
         )
+        if self.draft_cls is not None:
+            # if drafts are available, reindex them as well
+            siblings.extend(
+                self.draft_cls.get_records_by_parent(parent or record.parent)
+            )
 
         # TODO only index the current record immediately;
         #      all siblings should be sent to a high-priority celery task

--- a/tests/mock_module/permissions.py
+++ b/tests/mock_module/permissions.py
@@ -12,6 +12,7 @@ class PermissionPolicy(RecordPermissionPolicy):
     can_edit = [AnyUser()]
     can_new_version = [AnyUser()]
     can_search = [AnyUser()]
+    can_search_drafts = [AnyUser()]
     can_create = [AnyUser()]
     can_read = [AnyUser()]
     can_read_draft = [AnyUser()]


### PR DESCRIPTION
Previously, the reindexing of related records only reindexed sibling *records* (i.e. records sharing the same parent), but not sibling *drafts*.
Thus, the indexed variants of sibling drafts would become outdated when something in their parents changed.

Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1228