### PR TITLE
Bulk indexing for `rebuild_index`

### DIFF
--- a/invenio_drafts_resources/services/records/config.py
+++ b/invenio_drafts_resources/services/records/config.py
@@ -11,6 +11,7 @@
 """RecordDraft Service API config."""
 
 from flask_babelex import gettext as _
+from invenio_indexer.api import RecordIndexer
 from invenio_records_resources.services import ConditionalLink, RecordLink
 from invenio_records_resources.services import (
     RecordServiceConfig as RecordServiceConfigBase,
@@ -125,6 +126,9 @@ class RecordServiceConfig(RecordServiceConfigBase):
 
     # WHY: We want to force user input choice here.
     draft_cls = None
+
+    draft_indexer_cls = RecordIndexer
+    draft_indexer_queue_name = f"{RecordServiceConfigBase.indexer_queue_name}-drafts"
 
     schema = RecordSchema
 


### PR DESCRIPTION
Make the `service.rebuild_index` method utilize bulk indexing rather than indexing every item individually.
Also add a `draft_indexer` property to the service/config that is separate from the `indexer` property, because each indexer has a set `record_cls` which is used for looking up items to index by ID in bulk indexing.

This PR is related to https://github.com/inveniosoftware/invenio-records-resources/pull/419 ~and currently also includes the changes from https://github.com/inveniosoftware/invenio-drafts-resources/pull/207~.