### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@
 Changes
 =======
 
+Version 1.1.0 (2023-03-02)
+
+- remove deprecated flask-babelex dependency and imports
+- install invenio-i18n explicitly
+
 Version 1.0.4 (2023-02-22)
 
 - service: allow to ignore field-level permission checks in validate_draft

--- a/invenio_drafts_resources/__init__.py
+++ b/invenio_drafts_resources/__init__.py
@@ -10,6 +10,6 @@
 """Invenio Drafts Resources module to create REST APIs."""
 
 
-__version__ = "1.0.4"
+__version__ = "1.1.0"
 
 __all__ = ("__version__",)

--- a/invenio_drafts_resources/services/records/components/files.py
+++ b/invenio_drafts_resources/services/records/components/files.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2021 CERN.
 # Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,7 +10,7 @@
 
 """Records service component base classes."""
 
-from flask_babelex import gettext as _
+from invenio_i18n import gettext as _
 from invenio_records_resources.services.files.transfer import TransferType
 from invenio_records_resources.services.records.components import FilesOptionsComponent
 from marshmallow import ValidationError

--- a/invenio_drafts_resources/services/records/components/metadata.py
+++ b/invenio_drafts_resources/services/records/components/metadata.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2021 CERN.
 # Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,7 +10,6 @@
 
 """Records service component base classes."""
 
-from flask_babelex import gettext as _
 from invenio_records_resources.services.records.components import MetadataComponent
 
 

--- a/invenio_drafts_resources/services/records/components/pid.py
+++ b/invenio_drafts_resources/services/records/components/pid.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2021 CERN.
 # Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,7 +10,6 @@
 
 """Records service component base classes."""
 
-from flask_babelex import gettext as _
 from invenio_records_resources.services.records.components import ServiceComponent
 
 

--- a/invenio_drafts_resources/services/records/config.py
+++ b/invenio_drafts_resources/services/records/config.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2023 Graz University of Technology.
 #
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -10,7 +10,7 @@
 
 """RecordDraft Service API config."""
 
-from flask_babelex import gettext as _
+from invenio_i18n import gettext as _
 from invenio_indexer.api import RecordIndexer
 from invenio_records_resources.services import ConditionalLink, RecordLink
 from invenio_records_resources.services import (

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -52,7 +52,7 @@ if [[ ${keep_services} -eq 0 ]]; then
 fi
 
 python -m check_manifest
-python -m setup extract_messages --dry-run
+python -m setup extract_messages --output-file /dev/null
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch} --env)"
 # Note: expansion of pytest_args looks like below to not cause an unbound

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
+    invenio-i18n>=2.0.0,<3.0.0
     invenio-records-resources>=1.0.0,<2.0.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@
 [metadata]
 name = invenio-drafts-resources
 version = attr: invenio_drafts_resources.__version__
-description = "Invenio Drafts Resources module to create REST APIs"
+description = Invenio Drafts Resources module to create REST APIs
 long_description = file: README.rst, CHANGES.rst
 keywords = invenio records deposit submit versioning drafts
 license = MIT


### PR DESCRIPTION
- migrate: flask_babelex replaced by invenio_i18n
- fix: --dry-run ignored

- NOTE: Flask-Security-Invenio invenio-accounts invenio-admin invenio-files-rest invenio-i18n invenio-pidstore invenio-records invenio-records-resources invenio-theme have to be released first
