### PR TITLE
services: make files management permission-based

### DIFF
--- a/invenio_drafts_resources/services/records/permissions.py
+++ b/invenio_drafts_resources/services/records/permissions.py
@@ -28,3 +28,4 @@ class RecordPermissionPolicy(RecordPermissionPolicyBase):
     can_read_draft = [AnyUser()]
     can_update_draft = [AnyUser()]
     can_delete_draft = [AnyUser()]
+    can_manage_files = [AnyUser()]

--- a/tests/mock_module/permissions.py
+++ b/tests/mock_module/permissions.py
@@ -32,3 +32,4 @@ class PermissionPolicy(RecordPermissionPolicy):
     can_draft_commit_files = [AnyUser()]
     can_draft_read_files = [AnyUser()]
     can_draft_update_files = [AnyUser()]
+    can_manage_files = [AnyUser()]


### PR DESCRIPTION
- Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2021.

> **Warning**
> ~~This is a breaking change, that will require a major bump release!~~ Actually, this is not the case anymore. By default metadata-only records are allowed, so unless someone explicitly changes this permission or the config flag in their instance, the old behaviour still applies (i.e. it's possible to disable files).

:heart: Thank you for your contribution!

### Description

Please describe briefly your pull request.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
