### PR TITLE
api: don't override next version with new draft

### DIFF
--- a/invenio_drafts_resources/records/api.py
+++ b/invenio_drafts_resources/records/api.py
@@ -214,10 +214,10 @@ class Draft(Record):
                 # Note, other values like bucket_id values was kept in the
                 # soft-deleted record, so we are not setting them again here.
         except NoResultFound:
-            # If a draft was ever force deleted, then we will create the draft.
-            # This is a very exceptional case as normally, when we edit a
-            # record then the soft-deleted draft exists and we are in above
-            # case.
+            # If a draft was ever force deleted, then we re-create it.
+            # A classic scenario for this case is editing a published record
+            # after enough time has passed for its original draft to have
+            # been cleaned up. It then needs to be recreated.
             draft = cls.create(
                 {},
                 # A draft to edit a record must share the id and uuid.

--- a/invenio_drafts_resources/records/systemfields/versions.py
+++ b/invenio_drafts_resources/records/systemfields/versions.py
@@ -209,8 +209,8 @@ class VersionsField(SystemField):
         # The parent record is created on pre_create.
         versions = self.obj(record)
         if self._create and self._set_next:
-            # if fork is none - it's a new?
-            versions.set_next()
+            if not record.is_published:
+                versions.set_next()
         elif self._create and self._set_latest:
             versions.set_latest()
 

--- a/tests/records/test_api.py
+++ b/tests/records/test_api.py
@@ -135,7 +135,7 @@ def test_draft_parent_state_hard_delete(app, db, location):
 
 
 def test_new_draft_of_published_record_doesnt_override_next_draft_id(app, db, location):
-
+    """Test multiple drafts when editing multiple versions of the same record."""
     # Classic draft of published record having been cleaned up scenario
     record_1 = Record.publish(Draft.create({}))
     db.session.commit()


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2197

Although small, the fix has a larger context to understand. When a record is published, its draft is soft-deleted in the db until `cleanup_drafts` hard deletes it. When that happens, the published record has no associated draft anymore, so `edit` will create a completely new draft for it. However, that record may have a new version already (this is a fairly common occurrence in a running instance), so the new draft must not overwrite the reference to the `next_draft_id` stored in the parent. Because `next_draft_id` is used both to refer to a record's next version and a never published before draft's own id, we get interference. By checking if we are in the case of a record that has been published (only records that can have a new version) versus a record that has not, we can appropriately set that `next_draft_id`.

Another challenge with this PR was testing it. When trying to test this at the service level, we encounter [OpenSearch's delete behavior](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html#delete-versioning) (link to ElasticSearch but it applies to OpenSearch): the deleted document's `version` is kept around for 60s after deletion to overcome concurrency issues: Opensearch keeps a tombstone of deleted documents around and lets you reindex to a deleted document. So the version needs to stick around a little to make sure an update _sent_ just before deletion was processed doesn't create a new record (updates can create new records in ES/OS).  