### PR TITLE
components: lock files conditionally

### DIFF
--- a/invenio_drafts_resources/services/records/components/files.py
+++ b/invenio_drafts_resources/services/records/components/files.py
@@ -12,5 +12,5 @@ from invenio_records_resources.services.records.components.files import FilesAtt
 
 from .base import BaseRecordFilesComponent
 
-### Configure file attributes for files component
+# Configure file attributes for files component
 DraftFilesComponent = _make_cls(BaseRecordFilesComponent, {**FilesAttrConfig})

--- a/invenio_drafts_resources/services/records/config.py
+++ b/invenio_drafts_resources/services/records/config.py
@@ -35,6 +35,11 @@ def is_record(record, ctx):
     return not record.is_draft
 
 
+def lock_edit_published_files(record):
+    """Should published files be locked from editing in current record version."""
+    return True
+
+
 class SearchOptions(SearchOptionsBase):
     """Search options."""
 
@@ -142,6 +147,13 @@ class RecordServiceConfig(RecordServiceConfigBase):
         DraftMetadataComponent,
         PIDComponent,
     ]
+
+    default_files_enabled = True
+    # we disable by default media files. The feature is only available via REST API
+    # and they should be enabled before an upload is made i.e update the draft to
+    # set `media_files.enabled` to True
+    default_media_files_enabled = False
+    lock_edit_published_files = lock_edit_published_files
 
     links_item = {
         "self": ConditionalLink(

--- a/tests/mock_module/service.py
+++ b/tests/mock_module/service.py
@@ -26,7 +26,6 @@ class ServiceConfig(RecordServiceConfig):
     draft_cls = Draft
 
     schema = RecordSchema
-    default_files_enabled = True
 
     components = RecordServiceConfig.components + [
         DraftFilesComponent,

--- a/tests/resources/test_record_resource.py
+++ b/tests/resources/test_record_resource.py
@@ -189,7 +189,7 @@ def test_create_publish_new_revision(
     assert response.json["metadata"]["title"] == input_data["metadata"]["title"]
 
 
-def test_mutiple_edit(client, headers, input_data, location, search_clear):
+def test_multiple_edit(client, headers, input_data, location, search_clear):
     """Test the revision_id when editing record multiple times.
 
     This tests the `edit` service method.

--- a/tests/services/test_record_service.py
+++ b/tests/services/test_record_service.py
@@ -220,7 +220,7 @@ def test_create_publish_new_revision(app, service, identity_simple, input_data):
     assert record["metadata"]["title"] == edited_title
 
 
-def test_mutiple_edit(app, service, identity_simple, input_data):
+def test_multiple_edit(app, service, identity_simple, input_data):
     """Test the revision_id when editing record multiple times..
 
     This tests the `edit` service method.


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2259
* requires https://github.com/inveniosoftware/invenio-records-resources/pull/479

Context:
new functionality is added, we need to use bucket syncing to copy over files edited in the draft (if editing is allowed)