### PR TITLE
tasks: add margin time window for search to purge deleted documents

### DIFF
--- a/invenio_drafts_resources/services/records/service.py
+++ b/invenio_drafts_resources/services/records/service.py
@@ -631,13 +631,16 @@ class RecordService(RecordServiceBase):
             uow.register(RecordIndexOp(sibling, indexer=self.indexer))
 
     @unit_of_work()
-    def cleanup_drafts(self, timedelta, uow=None):
+    def cleanup_drafts(self, timedelta, uow=None, search_gc_deletes=60):
         """Hard delete of soft deleted drafts.
 
         :param int timedelta: timedelta that should pass since
             the last update of the draft in order to be hard deleted.
+        :param int search_gc_deletes: time in seconds, corresponding to the search cluster
+            setting `index.gc_deletes` (see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html#delete-versioning),
+            default to 60 seconds. Search cluster caches deleted documents for `index.gc_deletes` seconds.
         """
-        self.draft_cls.cleanup_drafts(timedelta)
+        self.draft_cls.cleanup_drafts(timedelta, search_gc_deletes)
 
     @unit_of_work()
     def reindex_latest_first(

--- a/invenio_drafts_resources/services/records/tasks.py
+++ b/invenio_drafts_resources/services/records/tasks.py
@@ -15,12 +15,15 @@ from invenio_records_resources.proxies import current_service_registry
 
 
 @shared_task(ignore_result=True)
-def cleanup_drafts(seconds=3600):
+def cleanup_drafts(seconds=3600, search_gc_deletes=60):
     """Hard delete of soft deleted drafts.
 
     :param int seconds: numbers of seconds that should pass since the
         last update of the draft in order to be hard deleted.
+    :param int search_gc_deletes: time in seconds, corresponding to the search cluster
+        setting `index.gc_deletes` (see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html#delete-versioning),
+        default to 60 seconds. Search cluster caches deleted documents for `index.gc_deletes` seconds.
     """
     timedelta_param = timedelta(seconds=seconds)
     service = current_service_registry.get("records")
-    service.cleanup_drafts(timedelta_param)
+    service.cleanup_drafts(timedelta_param, search_gc_deletes=search_gc_deletes)

--- a/tests/services/test_record_service_tasks.py
+++ b/tests/services/test_record_service_tasks.py
@@ -39,7 +39,7 @@ def test_hard_delete_soft_deleted_task(app, service, identity_simple, input_data
     assert (
         len(draft_model.query.filter(draft_model.is_deleted == True).all()) == 1  # noqa
     )
-    cleanup_drafts(seconds=0)
+    cleanup_drafts(seconds=0, search_gc_deletes=0)
 
     assert (
         len(draft_model.query.filter(draft_model.is_deleted == True).all()) == 0  # noqa

--- a/tests/services/test_services.py
+++ b/tests/services/test_services.py
@@ -38,7 +38,7 @@ def test_hard_delete_soft_deleted(app, service, identity_simple, input_data):
     assert (
         len(draft_model.query.filter(draft_model.is_deleted == True).all()) == 1  # noqa
     )
-    service.cleanup_drafts(timedelta(seconds=0))
+    service.cleanup_drafts(timedelta(seconds=0), search_gc_deletes=0)
 
     assert (
         len(draft_model.query.filter(draft_model.is_deleted == True).all()) == 0  # noqa
@@ -55,7 +55,7 @@ def test_hard_delete_soft_deleted_not_enough_time(
     assert (
         len(draft_model.query.filter(draft_model.is_deleted == True).all()) == 1  # noqa
     )
-    service.cleanup_drafts(timedelta(seconds=10))
+    service.cleanup_drafts(timedelta(seconds=10), search_gc_deletes=0)
 
     assert (
         len(draft_model.query.filter(draft_model.is_deleted == True).all()) == 1  # noqa


### PR DESCRIPTION
Soft deleted records are being kept in Opensearch for [60 seconds by default](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html#delete-versioning). That is happening for control of concurrent processes. In our case, when a soft deleted draft is cleaned up but it happened to be soft deleted in less than the time window that Opensearch finally cleans it up, then editing a new record is resulting in version conflict.

This PR adds a new kwarg to deduct the default deletion time and it can be passed as a parameter in case someone has configured the corresponding setting in a different value.