### PR TITLE
Record deletion: Allow passing of 'extra_filter' via kwargs to searches

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,51 +16,40 @@ on:
     branches: master
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron: "0 3 * * 6"
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason'
+        description: "Reason"
         required: false
-        default: 'Manual trigger'
+        default: "Manual trigger"
 
 jobs:
   Tests:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-          python-version: [3.7, 3.8, 3.9]
-          requirements-level: [pypi]
-          db-service: [postgresql10,postgresql13]
-          search-service: [opensearch2,elasticsearch7]
-          exclude:
-          - python-version: 3.7
-            db-service: postgresql13
-            search-service: opensearch2
-
-          - python-version: 3.7
-            db-service: postgresql13
-            search-service: elasticsearch7
-
+        python-version: [3.8, 3.9]
+        requirements-level: [pypi]
+        db-service: [postgresql11, postgresql13]
+        search-service: [opensearch2, elasticsearch7]
+        exclude:
           - python-version: 3.8
-            db-service: postgresql10
+            db-service: postgresql11
             search-service: opensearch2
 
           - python-version: 3.8
-            db-service: postgresql10
+            db-service: postgresql11
             search-service: elasticsearch7
 
           - python-version: 3.9
-            db-service: postgresql10
+            db-service: postgresql11
             search-service: opensearch2
 
           - python-version: 3.9
-            db-service: postgresql10
+            db-service: postgresql11
             search-service: elasticsearch7
-          include:
-          - db-service: postgresql10
-            DB_EXTRAS: "postgresql"
-
+        include:
           - db-service: postgresql13
             DB_EXTRAS: "postgresql"
 


### PR DESCRIPTION
Previously, the `service.read_drafts()` and `service.read_versions()` methods would not offer a possibility to specify `extra_filter` values that would be taken into account for the created search queries.

This would prevent the RDM-Records service to filter out _deleted records_ (not deleted drafts) from the user's dashboard.

In this PR, I merge the `kwargs["extra_filter"]` (if present) into the default one created in the `search_drafts()` and `read_versions()` methods respectively.
In this way, both the default filter as well as the custom one passed through the keyword arguments apply.