### PR TITLE
service: error when published record without draft

### DIFF
--- a/tests/services/test_record_service.py
+++ b/tests/services/test_record_service.py
@@ -131,7 +131,7 @@ def test_publish_draft(app, service, identity_simple, input_data):
         assert record[key] == value
 
     # Check draft deletion
-    with pytest.raises(NoResultFound):
+    with pytest.raises(PIDDoesNotExistError):
         # NOTE: Draft and Record have the same `id`
         draft = service.read_draft(identity_simple, record.id)
 


### PR DESCRIPTION
* Raise a proper error when trying to read a draft for a published record when it's not being edited (i.e draft doesn't exists).

