### PR TITLE
fix: TypeError multiple values for record

### DIFF
--- a/invenio_drafts_resources/services/records/config.py
+++ b/invenio_drafts_resources/services/records/config.py
@@ -35,6 +35,7 @@ def is_record(record, ctx):
     return not record.is_draft
 
 
+@staticmethod
 def lock_edit_published_files(service, identity, record=None):
     """Should published files be locked from editing in current record version."""
     return True


### PR DESCRIPTION
* functions bind to class attributes still get the self parameter which
  is not present in the definition of the lock_edit_published_files
  function. this result in `TypeError: lock_edit_published_files() got
  multiple values for argument 'record'`. by marking it as a static
  method the bind function will not get the self parameter anymore.


the full error is:
```
env/lib/python3.11/site-packages/invenio_drafts_resources/services/records/components/base.py", line 168, in edit
    lock_files = self.service.config.lock_edit_published_files(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: lock_edit_published_files() got multiple values for argument 'record'
```