### PR TITLE
Pluggable Transfer Types for Record Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dmypy.json
 
 # IDE
 .idea/
+.vscode/

--- a/invenio_drafts_resources/services/records/components/base.py
+++ b/invenio_drafts_resources/services/records/components/base.py
@@ -9,7 +9,8 @@
 
 """Base class for service components."""
 from invenio_i18n import gettext as _
-from invenio_records_resources.services.files.transfer import TransferType
+from invenio_records_resources.proxies import current_transfer_registry
+from invenio_records_resources.services.files.transfer.base import TransferStatus
 from invenio_records_resources.services.records.components import (
     BaseRecordFilesComponent as _BaseRecordFilesComponent,
 )
@@ -236,8 +237,12 @@ class BaseRecordFilesComponent(ServiceComponent, _BaseRecordFilesComponent):
         has_attached_object = file_record.file is not None
         if not has_attached_object:
             return False
-        transfer = TransferType(file_record.file.storage_class)
-        if transfer.is_completed:
+        transfer = current_transfer_registry.get_transfer(
+            record=file_record.record,
+            file_record=file_record,
+            file_service=self.service.draft_files,
+        )
+        if transfer.status == TransferStatus.COMPLETED:
             return True
 
     def publish(self, identity, draft=None, record=None):

--- a/tests/mock_module/permissions.py
+++ b/tests/mock_module/permissions.py
@@ -1,6 +1,6 @@
 """Example of a permission policy."""
 
-from invenio_records_permissions.generators import AnyUser
+from invenio_records_permissions.generators import AnyUser, SystemProcess
 
 from invenio_drafts_resources.services.records.permissions import RecordPermissionPolicy
 
@@ -33,7 +33,9 @@ class PermissionPolicy(RecordPermissionPolicy):
     can_draft_media_update_files = [AnyUser()]
     can_draft_media_delete_files = [AnyUser()]
 
-    can_draft_create_files = [AnyUser()]
+    # SystemProcess is needed for metadata extraction - 
+    # there is a 'create' action check there
+    can_draft_create_files = [AnyUser(), SystemProcess()]
     can_draft_set_content_files = [AnyUser()]
     can_draft_get_content_files = [AnyUser()]
     can_draft_commit_files = [AnyUser()]


### PR DESCRIPTION
### Description

This pull request implements pluggable transfer types for record files. It includes small changes in:

* Using transfer registry to get the transfer class
* Using transfer class to get the status of the uploaded file (and not allowing publishing draft if the status is not completed)
* Test updates to use the new API for fetched files 

Note: needs https://github.com/inveniosoftware/invenio-records-resources/pull/604 to work

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
