### PR TITLE
files: added errors on draft create

### DIFF
--- a/tests/services/test_record_service_files.py
+++ b/tests/services/test_record_service_files.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020-2024 CERN.
+# Copyright (C) 2020-2025 CERN.
 # Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or
@@ -597,7 +597,6 @@ def test_manage_files_permissions(
 
     # Not modifying files options (i.e. sending `files.enabled: true`) doesn't error
     draft = service.create(identity_simple, input_data)
-    assert not draft.errors
 
     # Modyfing/disabling files should return an error
     input_data["files"]["enabled"] = False

--- a/tests/services/test_record_service_files.py
+++ b/tests/services/test_record_service_files.py
@@ -522,12 +522,17 @@ def test_publish_with_fetch_files(
 def test_missing_files(app, service, identity_simple, input_data):
     # Test files.enabled = True when no files
     draft = service.create(identity_simple, input_data)
-    draft = service.update_draft(identity_simple, draft.id, input_data)
 
     # Files should be enabled
     assert draft.data["files"]["enabled"] is True
 
     # Missing files should be reported
+    assert draft.errors[0]["field"] == "files.enabled"
+    assert "Missing uploaded files." in draft.errors[0]["messages"][0]
+
+    draft = service.update_draft(identity_simple, draft.id, input_data)
+
+    assert draft.data["files"]["enabled"] is True
     assert draft.errors[0]["field"] == "files.enabled"
     assert "Missing uploaded files." in draft.errors[0]["messages"][0]
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description



### **I recommend reviewing by reading the commits in order** 

- first commit I add a test case that there should be an error on draft create
- second commit I extract `assign_files_enabled` into a common function as the implementations slightly differed but should be the same
- third commit I extract `check_files_exist` and add this to the `create` handler
- fourth commit is responding to christoph's review

---

On initial draft creation, no errors were being forwarded for empty files while on successive saves/updates they do.

Before and after of pressing save draft once (to create it). With my change the files not being there is also shown as an error, as both create and update check for the files

<img width="1683" height="1251" alt="image" src="https://github.com/user-attachments/assets/ef117797-1018-4013-b41f-201356b133f8" />

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
