### PR TITLE
fix: import-files permissions

### DIFF
--- a/invenio_drafts_resources/services/records/service.py
+++ b/invenio_drafts_resources/services/records/service.py
@@ -547,7 +547,7 @@ class RecordService(RecordServiceBase):
 
         # Read draft
         draft = self.draft_cls.pid.resolve(id_, registered_only=False)
-        self.require_permission(identity, "draft_create_files", record=draft)
+        self.require_permission(identity, "update_draft", record=draft)
 
         # Retrieve latest record
         record = self.record_cls.get_record(draft.versions.latest_id)

--- a/tests/mock_module/permissions.py
+++ b/tests/mock_module/permissions.py
@@ -1,6 +1,12 @@
 """Example of a permission policy."""
 
 from invenio_records_permissions.generators import AnyUser, SystemProcess
+from invenio_records_resources.services.files.generators import IfTransferType
+from invenio_records_resources.services.files.transfer import (
+    FETCH_TRANSFER_TYPE,
+    LOCAL_TRANSFER_TYPE,
+    REMOTE_TRANSFER_TYPE,
+)
 
 from invenio_drafts_resources.services.records.permissions import RecordPermissionPolicy
 
@@ -35,7 +41,12 @@ class PermissionPolicy(RecordPermissionPolicy):
 
     # SystemProcess is needed for metadata extraction -
     # there is a 'create' action check there
-    can_draft_create_files = [AnyUser(), SystemProcess()]
+    can_draft_create_files = [
+        IfTransferType(LOCAL_TRANSFER_TYPE, AnyUser()),
+        IfTransferType(FETCH_TRANSFER_TYPE, AnyUser()),
+        IfTransferType(REMOTE_TRANSFER_TYPE, AnyUser()),
+        SystemProcess(),
+    ]
     can_draft_set_content_files = [AnyUser()]
     can_draft_get_content_files = [AnyUser()]
     can_draft_commit_files = [AnyUser()]


### PR DESCRIPTION
### Description  

(see https://github.com/inveniosoftware/docs-invenio-rdm/pull/737#discussion_r2156833316 for context)

When implementing pluggable transfer types, permissions for the `init_files` call (`POST /.../files`) were updated to require file metadata. This ensures the system can verify whether the user has permission to use the selected transfer type (since permissions may vary by transfer type and each uploaded file can use different transfer type).  

However, the `import_files` call—which copies files from a published record to a new version of the same record—relies on the same permission check *without* passing individual files. As a result, permission checks fail (access denied) when transfer-specific permissions are enforced (e.g., in RDM).  

This PR changes the permission check to `update_draft` instead. The rationale is that we are copying file references from a published record to its draft, and permissions for these files were already verified during their initial upload.  

*Tests*: This PR also tightens security in `conftest.py` to align permissions with those used in RDM.  

#### Alternatives Considered  

1. **Call the original permission check (`draft_create_files`) for each file in the published record.**  
   - Unclear how to handle cases where the user only has permission for a subset of files. Should the operation copy only those files or fail entirely?  
   - The semantic meaning differs—this operation copies existing file references rather than initiating a new upload.  

2. **Introduce a new permission (`draft_import_files`).**  
   - No clear use case was found where a user with `update_draft` permissions should *not* be allowed to copy files from the previous version.  

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
