### PR TITLE
fix(resource): consume unread request body in edit endpoint

### DIFF
--- a/invenio_drafts_resources/resources/records/resource.py
+++ b/invenio_drafts_resources/resources/records/resource.py
@@ -9,7 +9,7 @@
 
 """Invenio Drafts Resources module to create REST APIs."""
 
-from flask import g
+from flask import g, request
 from flask_resources import (
     JSONSerializer,
     ResponseHandler,
@@ -147,6 +147,11 @@ class RecordResource(RecordResourceBase):
 
         POST /records/:pid_value/draft
         """
+        # Consume any unread request body to prevent connection errors
+        # when clients send large/chunked payloads that this endpoint
+        # does not use. The body is not cached since it is not needed.
+        # See invenio-app-rdm#3357.
+        request.get_data(cache=False)
         item = self.service.edit(
             g.identity,
             resource_requestctx.view_args["pid_value"],

--- a/tests/resources/test_record_resource.py
+++ b/tests/resources/test_record_resource.py
@@ -221,6 +221,33 @@ def test_multiple_edit(client, headers, input_data, location, search_clear):
     assert response.json["revision_id"] == 13
 
 
+def test_edit_with_large_payload(client, headers, input_data, location, search_clear):
+    """Test that editing a record with a large payload does not fail.
+
+    When clients send large/chunked payloads to POST /records/:pid_value/draft,
+    the endpoint must consume the unread request body to prevent connection
+    errors (e.g. ChunkedEncodingError). See invenio-app-rdm#3357.
+    """
+    recid = _create_and_publish(client, headers, input_data)
+
+    # Send a large payload (> 126KB) to the edit endpoint which does not
+    # expect a request body. Without the fix, this would cause the server
+    # to drop the connection before the client finishes sending.
+    large_payload = (
+        '{"metadata": {"title": "Large Payload", "pad": "' + ("x" * 200000) + '"}}'
+    )
+
+    response = client.post(
+        f"/mocks/{recid}/draft",
+        data=large_payload,
+        content_type="application/json",
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    assert response.json["id"] == recid
+
+
 def test_redirect_to_latest_version(client, headers, input_data, location):
     """Creates a new version of a record.
 


### PR DESCRIPTION
Fixes inveniosoftware/invenio-app-rdm#3357

:heart: Thank you for your contribution!

### Description

This PR fixes an issue where `POST /records/:pid_value/draft` fails for large records due to a `ChunkedEncodingError` (socket closed) when chunked transfer encoding is used by the requesting client.

Since the [edit()](cci:1://file:///Users/roberoi/Desktop/CERN/invenio-drafts-resources/invenio_drafts_resources/resources/records/resource.py:141:4-158:34) endpoint does not read the request body, Werkzeug closes the stream early while the client is still sending chunks. Adding `request.get_data()` inside the [edit()](cci:1://file:///Users/roberoi/Desktop/CERN/invenio-drafts-resources/invenio_drafts_resources/resources/records/resource.py:141:4-158:34) method drains the unread payload, preventing premature socket closure.

Changes:
* Added `request.get_data()` in `RecordResource.edit()` to consume any unread request body before proceeding.
* Added regression test [test_edit_with_large_payload](cci:1://file:///Users/roberoi/Desktop/CERN/invenio-drafts-resources/tests/resources/test_record_resource.py:223:0-247:39) to verify large payloads do not cause connection errors.

Impact: "Prevents a fatal ChunkedEncodingError (urllib3/requests IncompleteRead) when clients submit large (>126KB) payloads to the draft edit endpoint, improving API reliability."

Signed-off-by: Rishabh Oberoi rishabhoberoi05@gmail.com

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub's Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository's license.
2. You agree that you have the right to license your contribution under the current repository's license.
