### PR TITLE
fix(tests): alembic tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@
 Changes
 =======
 
+Version v10.0.0 (released 2026-05-29)
+
+- chore(setup): bump dependencies
+- fix(tests): alembic tests
+
 Version v9.0.2 (released 2026-05-04)
 
 - fix(auditlog): don't require session to accommodate API calls

--- a/invenio_drafts_resources/__init__.py
+++ b/invenio_drafts_resources/__init__.py
@@ -11,6 +11,6 @@
 
 """Invenio Drafts Resources module to create REST APIs."""
 
-__version__ = "9.0.2"
+__version__ = "10.0.0"
 
 __all__ = ("__version__",)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,15 +28,15 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     invenio-i18n>=3.0.0,<4.0.0
-    invenio-records-resources>=9.0.0,<10.0.0
-    invenio-audit-logs>=2.0.0,<3.0.0
+    invenio-records-resources>=10.0.0,<11.0.0
+    invenio-audit-logs>=3.0.0,<4.0.0
 
 [options.extras_require]
 tests =
     pytest-black>=0.6.0
     pytest-invenio>=4.0.0,<5.0.0
     invenio-app>=3.0.0,<4.0.0
-    invenio-users-resources>=10.0.0,<11.0.0
+    invenio-users-resources>=11.0.0,<12.0.0
     Sphinx>=4.5.0
     invenio-db[mysql,postgresql]>=2.2.0,<3.0.0
 elasticsearch7 =

--- a/tests/mock_module/api.py
+++ b/tests/mock_module/api.py
@@ -1,3 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2025 Northwestern University.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio-Drafts-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
 """Example of a record draft API."""
 
 from invenio_records.systemfields import ConstantField, ModelField
@@ -12,14 +24,14 @@ from invenio_drafts_resources.services.records.components.media_files import (
 )
 
 from .models import (
-    DraftMetadata,
     FileDraftMetadata,
     FileRecordMetadata,
     MediaFileDraftMetadata,
     MediaFileRecordMetadata,
-    ParentRecordMetadata,
-    ParentState,
-    RecordMetadata,
+    MockDraftMetadata,
+    MockParentRecordMetadata,
+    MockParentState,
+    MockRecordMetadata,
 )
 
 
@@ -27,7 +39,7 @@ class ParentRecord(ParentRecordBase):
     """Example parent record."""
 
     # Configuration
-    model_cls = ParentRecordMetadata
+    model_cls = MockParentRecordMetadata
 
     # System fields
     schema = ConstantField(
@@ -53,8 +65,8 @@ class Record(RecordBase):
     """Example record API."""
 
     # Configuration
-    model_cls = RecordMetadata
-    versions_model_cls = ParentState
+    model_cls = MockRecordMetadata
+    versions_model_cls = MockParentState
     parent_record_cls = ParentRecord
 
     # System fields
@@ -137,8 +149,8 @@ class Draft(DraftBase):
     """Example record API."""
 
     # Configuration
-    model_cls = DraftMetadata
-    versions_model_cls = ParentState
+    model_cls = MockDraftMetadata
+    versions_model_cls = MockParentState
     parent_record_cls = ParentRecord
 
     # System fields

--- a/tests/mock_module/models.py
+++ b/tests/mock_module/models.py
@@ -1,3 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2025 Northwestern University.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio-Drafts-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
 """Example of a record model."""
 
 from invenio_db import db
@@ -13,44 +25,44 @@ from invenio_drafts_resources.records import (
 )
 
 
-class ParentRecordMetadata(db.Model, RecordMetadataBase):
+class MockParentRecordMetadata(db.Model, RecordMetadataBase):
     """Model for mock module metadata."""
 
     __tablename__ = "parent_mock_metadata"
 
 
-class DraftMetadata(db.Model, DraftMetadataBase, ParentRecordMixin):
+class MockDraftMetadata(db.Model, DraftMetadataBase, ParentRecordMixin):
     """Model for mock module metadata."""
 
     __tablename__ = "draft_mock_metadata"
-    __parent_record_model__ = ParentRecordMetadata
+    __parent_record_model__ = MockParentRecordMetadata
 
     bucket_id = db.Column(UUIDType, db.ForeignKey(Bucket.id), index=True)
     bucket = db.relationship(Bucket, foreign_keys=[bucket_id])
 
 
-class RecordMetadata(db.Model, RecordMetadataBase, ParentRecordMixin):
+class MockRecordMetadata(db.Model, RecordMetadataBase, ParentRecordMixin):
     """Model for mock module metadata."""
 
     __tablename__ = "record_mock_metadata"
-    __parent_record_model__ = ParentRecordMetadata
+    __parent_record_model__ = MockParentRecordMetadata
 
     bucket_id = db.Column(UUIDType, db.ForeignKey(Bucket.id), index=True)
     bucket = db.relationship(Bucket, foreign_keys=[bucket_id])
 
 
-class ParentState(db.Model, ParentRecordStateMixin):
+class MockParentState(db.Model, ParentRecordStateMixin):
     """Model for mock module for parent state."""
 
-    __parent_record_model__ = ParentRecordMetadata
-    __record_model__ = RecordMetadata
-    __draft_model__ = DraftMetadata
+    __parent_record_model__ = MockParentRecordMetadata
+    __record_model__ = MockRecordMetadata
+    __draft_model__ = MockDraftMetadata
 
 
 class FileRecordMetadata(db.Model, RecordMetadataBase, FileRecordModelMixin):
     """Model for mock module record files."""
 
-    __record_model_cls__ = RecordMetadata
+    __record_model_cls__ = MockRecordMetadata
 
     __tablename__ = "mock_record_files"
 
@@ -58,7 +70,7 @@ class FileRecordMetadata(db.Model, RecordMetadataBase, FileRecordModelMixin):
 class MediaFileRecordMetadata(db.Model, RecordMetadataBase, FileRecordModelMixin):
     """Model for mock module record files."""
 
-    __record_model_cls__ = RecordMetadata
+    __record_model_cls__ = MockRecordMetadata
 
     __tablename__ = "mock_record_media_files"
 
@@ -66,7 +78,7 @@ class MediaFileRecordMetadata(db.Model, RecordMetadataBase, FileRecordModelMixin
 class FileDraftMetadata(db.Model, RecordMetadataBase, FileRecordModelMixin):
     """Model for mock module draft files."""
 
-    __record_model_cls__ = DraftMetadata
+    __record_model_cls__ = MockDraftMetadata
 
     __tablename__ = "mock_draft_files"
 
@@ -74,6 +86,6 @@ class FileDraftMetadata(db.Model, RecordMetadataBase, FileRecordModelMixin):
 class MediaFileDraftMetadata(db.Model, RecordMetadataBase, FileRecordModelMixin):
     """File associated with a draft."""
 
-    __record_model_cls__ = DraftMetadata
+    __record_model_cls__ = MockDraftMetadata
 
     __tablename__ = "mock_drafts_media_files"

--- a/tests/mock_module/permissions.py
+++ b/tests/mock_module/permissions.py
@@ -1,3 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2025 Northwestern University.
+#
+# Invenio-Drafts-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
 """Example of a permission policy."""
 
 from invenio_records_permissions.generators import AnyUser, SystemProcess

--- a/tests/records/test_api.py
+++ b/tests/records/test_api.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -15,10 +16,10 @@ from invenio_search import current_search_client
 from jsonschema import ValidationError
 from mock_module.api import Draft, ParentRecord, Record
 from mock_module.models import (
-    DraftMetadata,
-    ParentRecordMetadata,
-    ParentState,
-    RecordMetadata,
+    MockDraftMetadata,
+    MockParentRecordMetadata,
+    MockParentState,
+    MockRecordMetadata,
 )
 from sqlalchemy import inspect
 from sqlalchemy.orm.exc import NoResultFound
@@ -57,10 +58,10 @@ def test_draft_create_parent_state(app, db, location):
     db.session.commit()
 
     # Assert that associated objects were created
-    assert ParentState.query.count() == 1
-    assert DraftMetadata.query.count() == 1
-    assert ParentRecordMetadata.query.count() == 1
-    assert RecordMetadata.query.count() == 0
+    assert MockParentState.query.count() == 1
+    assert MockDraftMetadata.query.count() == 1
+    assert MockParentRecordMetadata.query.count() == 1
+    assert MockRecordMetadata.query.count() == 0
 
     def assert_state(d):
         # An initial draft is not published, so latest_id/index is None
@@ -129,10 +130,10 @@ def test_draft_parent_state_hard_delete(app, db, location):
     draft.delete(force=True)
     db.session.commit()
     # Make sure no parent and no parent state is left-behind
-    assert ParentState.query.count() == 0
-    assert ParentRecordMetadata.query.count() == 0
-    assert DraftMetadata.query.count() == 0
-    assert RecordMetadata.query.count() == 0
+    assert MockParentState.query.count() == 0
+    assert MockParentRecordMetadata.query.count() == 0
+    assert MockDraftMetadata.query.count() == 0
+    assert MockRecordMetadata.query.count() == 0
 
 
 def test_new_draft_of_published_record_doesnt_override_next_draft_id(app, db, location):
@@ -206,10 +207,10 @@ def test_draft_parent_state_hard_delete_with_parent(app, db, location):
     draft.delete(force=True)
     db.session.commit()
     # Make sure parent/parent state is still there
-    assert ParentState.query.count() == 1
-    assert ParentRecordMetadata.query.count() == 1
-    assert RecordMetadata.query.count() == 1
-    assert DraftMetadata.query.count() == 0
+    assert MockParentState.query.count() == 1
+    assert MockParentRecordMetadata.query.count() == 1
+    assert MockRecordMetadata.query.count() == 1
+    assert MockDraftMetadata.query.count() == 0
 
     record = Record.get_record(record.id)
     assert record.versions.next_draft_id is None
@@ -228,9 +229,9 @@ def test_draft_parent_state_soft_delete(app, db, location):
     draft.delete(force=False)
     db.session.commit()
 
-    assert ParentState.query.count() == 1
-    assert ParentRecordMetadata.query.count() == 1
-    assert RecordMetadata.query.count() == 1
+    assert MockParentState.query.count() == 1
+    assert MockParentRecordMetadata.query.count() == 1
+    assert MockRecordMetadata.query.count() == 1
 
     record = Record.get_record(record.id)
     assert record.versions.next_draft_id is None

--- a/tests/services/test_record_service_files.py
+++ b/tests/services/test_record_service_files.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2024 CERN.
 # Copyright (C) 2020-2021 Northwestern University.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Drafts-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -26,7 +27,7 @@ from invenio_records_resources.services.files.transfer.constants import (
     REMOTE_TRANSFER_TYPE,
 )
 from marshmallow.exceptions import ValidationError
-from mock_module.models import DraftMetadata, FileDraftMetadata, FileRecordMetadata
+from mock_module.models import FileDraftMetadata, FileRecordMetadata, MockDraftMetadata
 from mock_module.permissions import PermissionPolicy
 from mock_module.service import ServiceConfig
 
@@ -153,7 +154,9 @@ def test_edit_delete(app, db, service, input_data, identity_simple, monkeypatch)
     assert_counts(buckets=2, objs=1, fileinstances=1, filedrafts=0, filerecords=1)
 
     # Cleanup deleted drafts.
-    c = DraftMetadata.query.filter(DraftMetadata.is_deleted == True).delete()  # noqa
+    c = MockDraftMetadata.query.filter(
+        MockDraftMetadata.is_deleted == True
+    ).delete()  # noqa
     assert c == 1
     db.session.commit()
 
@@ -200,7 +203,9 @@ def test_edit_delete_media_files(
     assert_counts(buckets=2, objs=2, fileinstances=2, filedrafts=0, filerecords=1)
 
     # Cleanup deleted drafts.
-    c = DraftMetadata.query.filter(DraftMetadata.is_deleted == True).delete()  # noqa
+    c = MockDraftMetadata.query.filter(
+        MockDraftMetadata.is_deleted == True
+    ).delete()  # noqa
     assert c == 1
     db.session.commit()
 
@@ -231,7 +236,9 @@ def test_edit_publish(app, db, service, input_data, identity_simple, monkeypatch
     assert_counts(buckets=2, objs=1, fileinstances=1, filedrafts=0, filerecords=1)
 
     # Cleanup deleted drafts.
-    c = DraftMetadata.query.filter(DraftMetadata.is_deleted == True).delete()  # noqa
+    c = MockDraftMetadata.query.filter(
+        MockDraftMetadata.is_deleted == True
+    ).delete()  # noqa
     assert c == 1
     db.session.commit()
 

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 CERN.
+# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio-drafts-resources is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+"""Test invenio-drafts-resources alembic."""
+
+import pytest
+from invenio_db.utils import alembic_test_context, drop_alembic_version_table
+
+
+def test_alembic(app, db, extra_entry_points):
+    """Test alembic recipes."""
+    ext = app.extensions["invenio-db"]
+
+    if db.engine.name == "sqlite":
+        raise pytest.skip("Upgrades are not supported on SQLite.")
+
+    app.config["ALEMBIC_CONTEXT"] = alembic_test_context()
+
+    # Check that this package's SQLAlchemy models have been properly registered
+    tables = [x for x in db.metadata.tables]
+    assert "files_location" in tables
+    assert "files_bucket" in tables
+
+    def assert_no_unexpected_migrations():
+        # names created by RecordTypeFactory in tests and registered to sqlalchemy
+        extra_names = []
+        unexpected_migrations = [
+            m
+            for m in ext.alembic.compare_metadata()
+            if "mock" not in m[1].name.lower() and m[1].name.lower() not in extra_names
+        ]
+        assert unexpected_migrations == []
+
+    # Check that Alembic agrees that there's no further tables to create.
+    assert_no_unexpected_migrations()
+
+    # Drop everything and recreate tables all with Alembic
+    db.drop_all()
+    drop_alembic_version_table()
+    ext.alembic.upgrade()
+    ext.alembic.downgrade("dbdbc1b19cf2")
+    ext.alembic.upgrade()
+
+    assert_no_unexpected_migrations()
+
+    drop_alembic_version_table()


### PR DESCRIPTION
### Description

* Renamed RecordMetadata to MockRecordMetadata to prevent alembic conflicts
* Added alembic test

See https://github.com/inveniosoftware/invenio-records-resources/pull/681 for details on the renaming reasons.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
