### PR TITLE
fix(cleanup): batch draft hard-deletion to bound memory

### DIFF
--- a/invenio_drafts_resources/records/api.py
+++ b/invenio_drafts_resources/records/api.py
@@ -253,26 +253,38 @@ class Draft(Record):
         return draft
 
     @classmethod
-    def cleanup_drafts(cls, td, search_gc_deletes=60):
-        """Clean up (hard delete) all the soft deleted drafts.
+    def cleanup_drafts(cls, td, search_gc_deletes=60, max_drafts=1000):
+        """Hard delete up to ``max_drafts`` soft-deleted drafts; return how many.
 
         The soft-deleted drafts in the last timedelta span of time won't be deleted,
         including `search_gc_deletes` seconds timedelta. This ensures that only
         drafts fully removed from the search cluster can be hard-deleted (e.g. when
         `td` is very short), avoiding search conflicts.
 
+        At most ``max_drafts`` drafts are processed, so peak memory stays bounded.
+        The caller drives the loop (call until this returns 0) and owns the
+        transaction; see ``RecordService.cleanup_drafts``.
+
         :param int search_gc_deletes: time in seconds, corresponding to the search cluster
             setting `index.gc_deletes` (see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html#delete-versioning),
             default to 60 seconds. Search cluster caches deleted documents for `index.gc_deletes` seconds.
+        :param int max_drafts: maximum number of drafts to delete in this call.
+        :returns: number of drafts hard-deleted (0 when none remain).
         """
         timestamp = (
             datetime.now(timezone.utc) - td - timedelta(seconds=search_gc_deletes)
         )
         draft_model = cls.model_cls
-        models = draft_model.query.filter(
-            draft_model.is_deleted == True,  # noqa
-            draft_model.updated < timestamp,
-        ).all()
+        models = (
+            draft_model.query.filter(
+                draft_model.is_deleted == True,  # noqa
+                draft_model.updated < timestamp,
+            )
+            .limit(max_drafts)
+            .all()
+        )
+        if not models:
+            return 0
 
         # we need to clear the foreign keys in the version info
         for model in models:
@@ -286,3 +298,4 @@ class Draft(Record):
         draft_model.query.filter(draft_model.id.in_(ids)).delete(
             synchronize_session=False
         )
+        return len(ids)

--- a/invenio_drafts_resources/services/records/service.py
+++ b/invenio_drafts_resources/services/records/service.py
@@ -18,6 +18,7 @@ from invenio_records_resources.services.uow import (
     RecordCommitOp,
     RecordDeleteOp,
     RecordIndexOp,
+    UnitOfWork,
     unit_of_work,
 )
 from invenio_search.engine import dsl
@@ -693,17 +694,31 @@ class RecordService(RecordServiceBase):
 
         return draft, parent
 
-    @unit_of_work()
-    def cleanup_drafts(self, timedelta, uow=None, search_gc_deletes=60):
+    def cleanup_drafts(
+        self, timedelta, uow=None, search_gc_deletes=60, batch_size=1000
+    ):
         """Hard delete of soft deleted drafts.
+
+        Each batch of ``batch_size`` drafts is its own unit of work, so peak memory
+        stays bounded and progress is committed incrementally (a crash mid-run keeps
+        whatever was already deleted). ``uow`` is accepted for signature
+        compatibility but ignored: cleanup owns its own per-batch transactions.
 
         :param int timedelta: timedelta that should pass since
             the last update of the draft in order to be hard deleted.
         :param int search_gc_deletes: time in seconds, corresponding to the search cluster
             setting `index.gc_deletes` (see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html#delete-versioning),
             default to 60 seconds. Search cluster caches deleted documents for `index.gc_deletes` seconds.
+        :param int batch_size: number of drafts to delete per batch (bounds memory).
         """
-        self.draft_cls.cleanup_drafts(timedelta, search_gc_deletes)
+        while True:
+            with UnitOfWork() as batch_uow:
+                deleted = self.draft_cls.cleanup_drafts(
+                    timedelta, search_gc_deletes, max_drafts=batch_size
+                )
+                batch_uow.commit()
+            if not deleted:
+                break
 
     @unit_of_work()
     def reindex_latest_first(

--- a/invenio_drafts_resources/services/records/tasks.py
+++ b/invenio_drafts_resources/services/records/tasks.py
@@ -10,7 +10,7 @@ from invenio_records_resources.proxies import current_service_registry
 
 
 @shared_task(ignore_result=True)
-def cleanup_drafts(seconds=3600, search_gc_deletes=60):
+def cleanup_drafts(seconds=3600, search_gc_deletes=60, batch_size=1000):
     """Hard delete of soft deleted drafts.
 
     :param int seconds: numbers of seconds that should pass since the
@@ -18,7 +18,10 @@ def cleanup_drafts(seconds=3600, search_gc_deletes=60):
     :param int search_gc_deletes: time in seconds, corresponding to the search cluster
         setting `index.gc_deletes` (see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html#delete-versioning),
         default to 60 seconds. Search cluster caches deleted documents for `index.gc_deletes` seconds.
+    :param int batch_size: number of drafts to delete per batch (bounds memory).
     """
     timedelta_param = timedelta(seconds=seconds)
     service = current_service_registry.get("records")
-    service.cleanup_drafts(timedelta_param, search_gc_deletes=search_gc_deletes)
+    service.cleanup_drafts(
+        timedelta_param, search_gc_deletes=search_gc_deletes, batch_size=batch_size
+    )

--- a/tests/records/test_api.py
+++ b/tests/records/test_api.py
@@ -191,6 +191,30 @@ def test_cleanup_drafts_preserves_next_version_draft(app, db, location):
     assert record_v1.versions.next_draft_id is None
 
 
+def test_cleanup_drafts_batch_limits_and_counts(app, db, location):
+    """Cleanup handles one batch at a time and reports how many it deleted."""
+    draft_model = Draft.model_cls
+    ids = []
+    for _ in range(3):
+        draft = Draft.create({})
+        db.session.commit()
+        draft.delete(force=False)
+        db.session.commit()
+        ids.append(draft.id)
+
+    # A single call deletes at most max_drafts and returns that count.
+    deleted = Draft.cleanup_drafts(timedelta(0), search_gc_deletes=0, max_drafts=2)
+    db.session.commit()
+    assert deleted == 2
+    assert draft_model.query.filter(draft_model.id.in_(ids)).count() == 1
+
+    # Caller loops until it drains, then gets 0.
+    assert Draft.cleanup_drafts(timedelta(0), search_gc_deletes=0, max_drafts=2) == 1
+    db.session.commit()
+    assert Draft.cleanup_drafts(timedelta(0), search_gc_deletes=0, max_drafts=2) == 0
+    assert draft_model.query.filter(draft_model.id.in_(ids)).count() == 0
+
+
 def test_draft_parent_state_hard_delete_with_parent(app, db, location):
     """Test force deletion of a draft."""
     # Initial state: A previous reccord version exists, in addition to draft

--- a/tests/services/test_services.py
+++ b/tests/services/test_services.py
@@ -10,7 +10,7 @@ Test to add:
 - Read with missing pid
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -55,3 +55,38 @@ def test_hard_delete_soft_deleted_not_enough_time(
     assert (
         len(draft_model.query.filter(draft_model.is_deleted == True).all()) == 1  # noqa
     )
+
+
+def test_cleanup_drafts_batches(app, db, service, location):
+    """The service loops over batches until the whole backlog is cleaned."""
+    draft_model = service.draft_cls.model_cls
+
+    # More expired soft-deleted drafts than fit in one batch.
+    expired_ids = []
+    for _ in range(5):
+        draft = service.draft_cls.create({})
+        db.session.commit()
+        draft.delete(force=False)
+        db.session.commit()
+        expired_ids.append(draft.id)
+
+    # Age them past the cutoff (a bulk update skips the before_update event).
+    old = datetime.now(timezone.utc) - timedelta(days=1)
+    draft_model.query.filter(draft_model.id.in_(expired_ids)).update(
+        {draft_model.updated: old}, synchronize_session=False
+    )
+    db.session.commit()
+
+    # A recent soft-deleted draft, still within the cutoff.
+    recent = service.draft_cls.create({})
+    db.session.commit()
+    recent.delete(force=False)
+    db.session.commit()
+
+    # batch_size < number of expired drafts => several batches.
+    service.cleanup_drafts(timedelta(hours=1), search_gc_deletes=0, batch_size=2)
+
+    # All expired drafts are hard-deleted; the recent one is untouched.
+    assert draft_model.query.filter(draft_model.id.in_(expired_ids)).count() == 0
+    recent_row = draft_model.query.filter_by(id=recent.id).one_or_none()
+    assert recent_row is not None and recent_row.is_deleted


### PR DESCRIPTION
> AI disclaimer: the new test cases were written with Claude Code.

`cleanup_drafts` hard-deletes soft-deleted drafts, but it loaded the entire
backlog into memory at once. On a large backlog that consumes several GB and
gets OOM-killed before it reaches the delete, so nothing is deleted, the
backlog keeps growing, and the next run OOMs sooner.

The fix processes the backlog in bounded batches:

* `Draft.cleanup_drafts` (data-access) deletes up to `max_drafts` soft-deleted
  drafts older than the cutoff and returns how many it removed (0 when none
  remain). It commits nothing and holds only one batch in memory.
* `RecordService.cleanup_drafts` drives the loop, one unit of work per batch,
  so peak memory stays bounded and progress is committed incrementally: a kill
  mid-run keeps whatever was already deleted.
* `batch_size` (default 1000) is threaded through the service and the Celery
  task; public signatures stay backwards-compatible.

The cutoff (`is_deleted` and `updated` older than `td + search_gc_deletes`),
the version-FK clearing, and `synchronize_session=False` are unchanged.
